### PR TITLE
Add windows to build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,10 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
This PR is a follow-up from [this comment](https://github.com/DataDog/datadog-traceroute/pull/3#issuecomment-3116936429) -- it adds Windows to our CI