### PR TITLE
Remove cache from go setup action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,6 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: 1.24.5
-          cache: true
       - run: go mod tidy
       - run: go test -tags=test -v ./...
       # - uses: docker/login-action@v1


### PR DESCRIPTION
Motivation:

https://github.com/DataDog/datadog-traceroute/actions/runs/16593290821

<img width="755" height="188" alt="image" src="https://github.com/user-attachments/assets/fce40cf3-99e5-4260-ade2-31d08a15ce6c" />
