### PR TITLE
[drivers] Properly close source/sink for TCP/UDP

### DIFF
--- a/tcp/tcp_traceroute.go
+++ b/tcp/tcp_traceroute.go
@@ -62,6 +62,7 @@ func (t *TCPv4) Traceroute() (*common.Results, error) {
 	}
 
 	driver := newTCPDriver(t, handle.Sink, handle.Source)
+	defer driver.Close()
 
 	params := common.TracerouteSerialParams{
 		TracerouteParams: common.TracerouteParams{

--- a/udp/udp_driver.go
+++ b/udp/udp_driver.go
@@ -6,6 +6,7 @@
 package udp
 
 import (
+	"errors"
 	"fmt"
 	"net/netip"
 	"sync"
@@ -196,4 +197,11 @@ func (u *udpDriver) handleProbeLayers() (*common.ProbeResponse, error) {
 		RTT:    rtt,
 		IsDest: ipPair.SrcAddr == u.getTargetAddrPort().Addr(),
 	}, nil
+}
+
+// Close closes the udpDriver
+func (u *udpDriver) Close() error {
+	sinkErr := u.sink.Close()
+	sourceErr := u.source.Close()
+	return errors.Join(sinkErr, sourceErr)
 }

--- a/udp/udp_traceroute.go
+++ b/udp/udp_traceroute.go
@@ -46,6 +46,7 @@ func (u *UDPv4) Traceroute() (*common.Results, error) {
 	}
 
 	driver := newUDPDriver(u, handle.Sink, handle.Source)
+	defer driver.Close()
 
 	params := common.TracerouteParallelParams{
 		TracerouteParams: common.TracerouteParams{


### PR DESCRIPTION
This PR fixes dangling FDs left over by traceroutes for TCP and UDP. ICMP already closes the FDs correctly.