### PR TITLE
[packets] Allow PacketFilterSpec to hint network tuple on other types

### DIFF
--- a/packets/cbpf_filters.go
+++ b/packets/cbpf_filters.go
@@ -78,7 +78,7 @@ func getClassicBPFFilter(spec PacketFilterSpec) ([]bpf.RawInstruction, error) {
 	case FilterTypeUDP:
 		return udpFilter, nil
 	case FilterTypeTCP:
-		return spec.TCPFilterConfig.GenerateTCP4Filter()
+		return spec.FilterConfig.GenerateTCP4Filter()
 	case FilterTypeSYNACK:
 		return tcpSynackFilter, nil
 	default:

--- a/packets/cbpf_filters_test.go
+++ b/packets/cbpf_filters_test.go
@@ -238,7 +238,7 @@ func TestClassicBPFFilters(t *testing.T) {
 	tcp4Syn := packetDef{"tcp4Syn", makeTcp4SynPacket(t)}
 	tcp4Synack := packetDef{"tcp4Synack", makeTcp4SynAckPacket(t)}
 
-	tcp4TupleFilter, err := TCPFilterConfig{
+	tcp4TupleFilter, err := FilterConfig{
 		Src: netip.MustParseAddrPort("127.0.0.1:345"),
 		Dst: netip.MustParseAddrPort("127.0.0.2:678"),
 	}.GenerateTCP4Filter()

--- a/packets/tcp_filter.go
+++ b/packets/tcp_filter.go
@@ -13,15 +13,15 @@ import (
 	"golang.org/x/net/bpf"
 )
 
-// TCPFilterConfig is the config for GenerateTCP4Filter
-type TCPFilterConfig struct {
+// FilterConfig is the config for GenerateTCP4Filter
+type FilterConfig struct {
 	Src netip.AddrPort
 	Dst netip.AddrPort
 }
 
 // GenerateTCP4Filter creates a classic BPF filter for TCP SOCK_RAW sockets.
 // It will only allow packets whose tuple matches the given config.
-func (c TCPFilterConfig) GenerateTCP4Filter() ([]bpf.RawInstruction, error) {
+func (c FilterConfig) GenerateTCP4Filter() ([]bpf.RawInstruction, error) {
 	if !c.Src.Addr().Is4() || !c.Dst.Addr().Is4() {
 		return nil, fmt.Errorf("GenerateTCP4Filter2: src=%s and dst=%s must be IPv4", c.Src.Addr(), c.Dst.Addr())
 	}

--- a/packets/types.go
+++ b/packets/types.go
@@ -22,15 +22,16 @@ type PacketFilterType int
 const (
 	// FilterTypeNone indicates no filter (all packets).
 	FilterTypeNone PacketFilterType = iota
-	// FilterTypeICMP indicates only ICMP packets
+	// FilterTypeICMP indicates only ICMP packets.
 	FilterTypeICMP
-	// FilterTypeUDP indicates only ICMP and UDP packets
+	// FilterTypeUDP indicates only ICMP and UDP packets.
+	// FilterConfig will contain the UDP source/destination 4-tuple.
 	FilterTypeUDP
 	// FilterTypeTCP indicates only ICMP and TCP packets.
-	// This one accepts a 4-tuple for source/dest.
+	// FilterConfig will contain the TCP source/destination 4-tuple.
 	FilterTypeTCP
 	// FilterTypeSYNACK indicates only TCP SYNACK packets.
-	// Does not accept a 4-tuple like FilterTypeTCP.
+	// FilterConfig will contain the source addr/port, but NOT the destination.
 	// This is used by SACK traceroute.
 	FilterTypeSYNACK
 )
@@ -39,6 +40,8 @@ const (
 type PacketFilterSpec struct {
 	// FilterType is which kind of packet filter to enable
 	FilterType PacketFilterType
-	// TCPFilterConfig is only read by FilterTypeTCP -- it contains the 4-tuple of source/dest
-	TCPFilterConfig TCPFilterConfig
+	// FilterConfig contains the 4-tuple of source/dest.
+	// Some fields may be unused for certain PacketFilterTypes -- refer
+	// to the PacketFilterType documentation
+	FilterConfig FilterConfig
 }

--- a/sack/traceroute_sack.go
+++ b/sack/traceroute_sack.go
@@ -120,6 +120,9 @@ func runSackTraceroute(ctx context.Context, p Params) (*sackResult, error) {
 	}
 	err = handle.Source.SetPacketFilter(packets.PacketFilterSpec{
 		FilterType: packets.FilterTypeSYNACK,
+		FilterConfig: packets.FilterConfig{
+			Src: p.Target,
+		},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("SACK traceroute failed to set packet filter: %w", err)
@@ -173,7 +176,7 @@ func runSackTraceroute(ctx context.Context, p Params) (*sackResult, error) {
 
 	err = handle.Source.SetPacketFilter(packets.PacketFilterSpec{
 		FilterType: packets.FilterTypeTCP,
-		TCPFilterConfig: packets.TCPFilterConfig{
+		FilterConfig: packets.FilterConfig{
 			Src: p.Target,
 			Dst: local.AddrPort(),
 		},

--- a/tcp/tcp_traceroute.go
+++ b/tcp/tcp_traceroute.go
@@ -52,7 +52,7 @@ func (t *TCPv4) Traceroute() (*common.Results, error) {
 	}
 	err = handle.Source.SetPacketFilter(packets.PacketFilterSpec{
 		FilterType: packets.FilterTypeTCP,
-		TCPFilterConfig: packets.TCPFilterConfig{
+		FilterConfig: packets.FilterConfig{
 			Src: netip.AddrPortFrom(targetAddr, t.DestPort),
 			Dst: netip.AddrPortFrom(localAddr, port),
 		},

--- a/tcp/tcpv4_unix.go
+++ b/tcp/tcpv4_unix.go
@@ -66,7 +66,7 @@ func (t *TCPv4) TracerouteSequential() (*common.Results, error) {
 	t.srcPort = port
 
 	// create a socket filter for TCP to reduce CPU usage
-	filterCfg := packets.TCPFilterConfig{
+	filterCfg := packets.FilterConfig{
 		Src: netip.AddrPortFrom(targetAddr, t.DestPort),
 		Dst: netip.AddrPortFrom(localAddr, port),
 	}

--- a/udp/udp_traceroute.go
+++ b/udp/udp_traceroute.go
@@ -8,6 +8,7 @@ package udp
 import (
 	"context"
 	"fmt"
+	"net/netip"
 	"time"
 
 	"github.com/DataDog/datadog-traceroute/common"
@@ -38,8 +39,15 @@ func (u *UDPv4) Traceroute() (*common.Results, error) {
 	if handle.MustClosePort {
 		conn.Close()
 	}
+
+	// TODO remove localAddr once UDPv4 only uses AddrPort
+	localAddr, _ := common.UnmappedAddrFromSlice(u.srcIP)
 	err = handle.Source.SetPacketFilter(packets.PacketFilterSpec{
 		FilterType: packets.FilterTypeUDP,
+		FilterConfig: packets.FilterConfig{
+			Src: netip.AddrPortFrom(targetAddr, u.TargetPort),
+			Dst: netip.AddrPortFrom(localAddr, u.srcPort),
+		},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("UDP traceroute failed to set packet filter: %w", err)


### PR DESCRIPTION
Jack wants to use the tuple to filter other network types like TCP SACK -- this adds the address/port to those filters