### PR TITLE
[linux] Fix linuxSink file descriptor handling

### DIFF
--- a/packets/packet_sink_linux.go
+++ b/packets/packet_sink_linux.go
@@ -19,6 +19,7 @@ import (
 
 // sinkLinux is an implementation of the packet sink interface for linux
 type sinkLinux struct {
+	sock    *os.File
 	rawConn syscall.RawConn
 }
 
@@ -59,6 +60,7 @@ func NewSinkLinux(addr netip.Addr) (Sink, error) {
 	}
 
 	return &sinkLinux{
+		sock:    sock,
 		rawConn: rawConn,
 	}, nil
 }
@@ -84,10 +86,5 @@ func (p *sinkLinux) WriteTo(buf []byte, addr netip.AddrPort) error {
 
 // Close closes the socket
 func (p *sinkLinux) Close() error {
-	var closeErr error
-	err := p.rawConn.Control(func(fd uintptr) {
-		closeErr = unix.Close(int(fd))
-	})
-
-	return errors.Join(closeErr, err)
+	return p.sock.Close()
 }


### PR DESCRIPTION
This fixes a bug in `linuxSink`. On darwin, `(*os.File) SyscallConn()` preserves a reference to the `*os.File` meaning it will not get garbage collected. I mistakenly thought linux did the same, but a SyscallConn on linux only holds onto the FD. Meaning, the os.File will get garbage collected, and that will close the FD at the wrong time, leading to problems.