### PR TITLE
[filters] Check for nil in SetBPFAndDrain

### DIFF
--- a/packets/attach_linux.go
+++ b/packets/attach_linux.go
@@ -80,7 +80,7 @@ func SetBPFAndDrain(c syscall.RawConn, filter []bpf.RawInstruction) error {
 	if err != nil {
 		return fmt.Errorf("SetBPFAndDrain control failed: %w", err)
 	}
-	if recvErr != syscall.EAGAIN {
+	if recvErr != nil && recvErr != syscall.EAGAIN {
 		return fmt.Errorf("SetBPFAndDrain failed to drain: %w", err)
 	}
 


### PR DESCRIPTION
Rarely we get this error running netpath at scale in staging:
```
SYS-PROBE | ERROR | (cmd/system-probe/modules/traceroute.go:72 in func1) | unable to run traceroute for host: 10.128.11.211: UDP traceroute failed to set packet filter: SetPacketFilter failed to apply BPF filter: SetBPFAndDrain failed to drain: %!w(<nil>)
```

Apparently this syscall can occasionally finish synchronously which results in a nil error. I think it happens on hosts with barely any network traffic.

## Release plan

I'm going to backport this to 7.71 as datadog-traceroute v0.1.5-hotfix1. I don't think this error is super common but I'd rather rule it out, especially across kernels.