### PR TITLE
Downgrade go.mod go versionto 1.24.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-traceroute
 
-go 1.24.6
+go 1.24.0
 
 require (
 	github.com/golang/mock v1.6.0


### PR DESCRIPTION
use 1.24.0 in datadog-traceroute to be on par with datadog-agent, but we still use 1.24.6 [when building](https://github.com/DataDog/datadog-traceroute/blob/main/.github/workflows/build.yml#L29)