### PR TITLE
[CNM-4361] e2e probes implementation

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -52,6 +52,7 @@ var rootCmd = &cobra.Command{
 			Hostname:          args[0],
 			Port:              Args.port,
 			Protocol:          Args.protocol,
+			MinTTL:            common.DefaultMinTTL,
 			MaxTTL:            Args.maxTTL,
 			Delay:             common.DefaultDelay,
 			Timeout:           timeout,
@@ -59,6 +60,7 @@ var rootCmd = &cobra.Command{
 			WantV6:            Args.wantV6,
 			ReverseDns:        Args.reverseDns,
 			TracerouteQueries: Args.tracerouteQueries,
+			E2eQueries:        Args.e2eQueries,
 		}
 
 		results, err := runner.RunTraceroute(cmd.Context(), params)

--- a/common/common.go
+++ b/common/common.go
@@ -23,7 +23,7 @@ const (
 	DefaultNetworkPathTimeout = 3000
 	DefaultPort               = 33434
 	DefaultTracerouteQueries  = 3
-	DefaultNumE2eProbes       = 50
+	DefaultNumE2eProbes       = 10
 	DefaultMinTTL             = 1
 	DefaultMaxTTL             = 30
 	DefaultDelay              = 50 //msec

--- a/common/common.go
+++ b/common/common.go
@@ -26,6 +26,7 @@ const (
 	DefaultNumE2eProbes       = 50
 	DefaultMinTTL             = 1
 	DefaultMaxTTL             = 30
+	DefaultE2eProbeTTL        = 200
 	DefaultDelay              = 50 //msec
 	DefaultProtocol           = "udp"
 	DefaultTcpMethod          = "syn"

--- a/common/common.go
+++ b/common/common.go
@@ -26,7 +26,6 @@ const (
 	DefaultNumE2eProbes       = 50
 	DefaultMinTTL             = 1
 	DefaultMaxTTL             = 30
-	DefaultE2eProbeTTL        = 200
 	DefaultDelay              = 50 //msec
 	DefaultProtocol           = "udp"
 	DefaultTcpMethod          = "syn"

--- a/common/traceroute_types.go
+++ b/common/traceroute_types.go
@@ -134,8 +134,12 @@ func ToHops(p TracerouteParams, probes []*ProbeResponse) ([]*result.TracerouteHo
 	for i, probe := range probes {
 		expectedTTL := int(p.MinTTL) + i
 		if probe != nil {
+			// Sanity check
+			if int(probe.TTL) != expectedTTL {
+				return nil, fmt.Errorf("probe TTL mismatch: expected %d, got %d", expectedTTL, probe.TTL)
+			}
 			hops[i] = &result.TracerouteHop{
-				TTL:       int(probe.TTL),
+				TTL:       expectedTTL,
 				IPAddress: probe.IP.AsSlice(),
 				RTT:       ConvertDurationToMs(probe.RTT),
 				IsDest:    probe.IsDest,

--- a/result/result.go
+++ b/result/result.go
@@ -129,6 +129,10 @@ func (r *Results) normalizeTracerouteRuns() {
 }
 
 func (r *Results) normalizeTracerouteHops() {
+	if len(r.Traceroute.Runs) == 0 {
+		return
+	}
+
 	var hopCounts []int
 	for _, run := range r.Traceroute.Runs {
 		hopCount := len(run.Hops)
@@ -161,61 +165,71 @@ func (r *Results) normalizeTracerouteHops() {
 }
 
 func (r *Results) normalizeE2eProbe() {
-	r.E2eProbe.RTTs = []float64{}
-	var packetSent, packetReceived int
-	var totalRTTs, minRTT, maxRTT float64
-	RTTs := []float64{}
+	r.E2eProbe.PacketsSent = len(r.E2eProbe.RTTs)
 
-	// TODO: Replace with "50x e2e probe impl"
-	//       Right now, we temporarily use single Traceroute data to fill e2e probe
-	for _, run := range r.Traceroute.Runs {
-		packetSent++
-		destHop := run.getDestinationHop()
-		if destHop == nil {
-			continue
-		}
+	// Count received packets (non-zero RTTs) and collect valid RTTs
+	var validRTTs []float64
+	packetsReceived := 0
 
-		packetReceived++
-		if destHop.RTT > maxRTT {
-			maxRTT = destHop.RTT
+	for _, rtt := range r.E2eProbe.RTTs {
+		if rtt > 0.0 {
+			packetsReceived++
+			validRTTs = append(validRTTs, rtt)
 		}
-		if destHop.RTT < minRTT || minRTT == 0 {
-			minRTT = destHop.RTT
-		}
-		RTTs = append(RTTs, destHop.RTT)
-
-		totalRTTs += destHop.RTT
 	}
 
-	if packetReceived > 0 {
-		r.E2eProbe.RTT.Avg = totalRTTs / float64(packetReceived)
-	}
-	r.E2eProbe.RTT.Min = minRTT
-	r.E2eProbe.RTT.Max = maxRTT
-	r.E2eProbe.PacketsSent = packetSent
-	r.E2eProbe.PacketsReceived = packetReceived
-	r.E2eProbe.PacketLossPercentage = float32(packetSent-packetReceived) / float32(packetSent)
-	r.E2eProbe.RTTs = RTTs
+	r.E2eProbe.PacketsReceived = packetsReceived
 
-	// compute jitter
-	// TODO: this is one way of computing jitter (https://www.rfc-editor.org/rfc/rfc4689.html#section-3.2.5)
-	//       but actual jitter computation for e2e probe will require further investigation
-	//       to choose the most suitable way to compute jitter.
-	if len(RTTs) >= 2 {
-		var totalJitter float64
-		var prevRtt float64
-		for _, rtt := range RTTs {
-			if prevRtt == 0 {
-				prevRtt = rtt
-				continue
+	// Calculate packet loss percentage
+	if r.E2eProbe.PacketsSent > 0 {
+		r.E2eProbe.PacketLossPercentage = float32(r.E2eProbe.PacketsSent-r.E2eProbe.PacketsReceived) / float32(r.E2eProbe.PacketsSent)
+	}
+
+	if len(validRTTs) > 0 {
+		var totalRTTs float64
+		minRTT := validRTTs[0]
+		maxRTT := validRTTs[0]
+
+		for _, rtt := range validRTTs {
+			totalRTTs += rtt
+			if rtt < minRTT {
+				minRTT = rtt
 			}
-			totalJitter += math.Abs(rtt - prevRtt)
+			if rtt > maxRTT {
+				maxRTT = rtt
+			}
 		}
-		r.E2eProbe.Jitter = totalJitter / float64(len(RTTs)-1)
+
+		r.E2eProbe.RTT.Avg = totalRTTs / float64(len(validRTTs))
+		r.E2eProbe.RTT.Min = minRTT
+		r.E2eProbe.RTT.Max = maxRTT
+	} else {
+		// No packets received
+		r.E2eProbe.RTT.Avg = 0.0
+		r.E2eProbe.RTT.Min = 0.0
+		r.E2eProbe.RTT.Max = 0.0
 	}
+
+	r.E2eProbe.Jitter = calculateJitter(validRTTs)
 }
 
-func (tr *TracerouteRun) getDestinationHop() *TracerouteHop {
+// calculateJitter computes the average jitter from a slice of RTT measurements.
+// Jitter is calculated as the mean absolute deviation of consecutive RTT differences.
+func calculateJitter(rtts []float64) float64 {
+	if len(rtts) < 2 {
+		return 0.0 // Jitter requires at least 2 RTT measurements
+	}
+
+	var sumDiffs float64
+	for i := 1; i < len(rtts); i++ {
+		diff := math.Abs(rtts[i] - rtts[i-1])
+		sumDiffs += diff
+	}
+
+	return sumDiffs / float64(len(rtts)-1)
+}
+
+func (tr *TracerouteRun) GetDestinationHop() *TracerouteHop {
 	for _, hop := range tr.Hops {
 		if hop.IsDest {
 			return hop

--- a/result/result.go
+++ b/result/result.go
@@ -94,22 +94,45 @@ type (
 
 // EnrichWithReverseDns enrich results with reverse dns
 func (r *Results) EnrichWithReverseDns() {
+	// collect unique IP addresses
+	uniqueIPs := make(map[string]net.IP)
 	for i := range r.Traceroute.Runs {
 		run := &r.Traceroute.Runs[i]
-		destRDns, err := reversedns.GetReverseDnsForIP(run.Destination.IPAddress)
-		if err != nil {
-			log.Debugf("failed to get reverse dns for destination IP: %s", err)
-		} else {
-			run.Destination.ReverseDns = destRDns
+		if run.Destination.IPAddress != nil {
+			uniqueIPs[run.Destination.IPAddress.String()] = run.Destination.IPAddress
 		}
+		for _, hop := range run.Hops {
+			if hop.IPAddress != nil {
+				uniqueIPs[hop.IPAddress.String()] = hop.IPAddress
+			}
+		}
+	}
 
-		for j := range run.Hops {
-			hop := run.Hops[j]
-			hopRDns, err := reversedns.GetReverseDnsForIP(hop.IPAddress)
-			if err != nil {
-				log.Debugf("failed to get reverse dns for destination IP: %s", err)
-			} else {
-				hop.ReverseDns = hopRDns
+	// perform reverse DNS lookup for each unique IP address
+	rdnsResults := make(map[string][]string)
+	for ipStr, ip := range uniqueIPs {
+		rdnsResult, err := reversedns.GetReverseDnsForIP(ip)
+		if err != nil {
+			log.Debugf("failed to get reverse dns for IP %s: %s", ipStr, err)
+			rdnsResults[ipStr] = nil // Store nil to indicate lookup was attempted but failed
+		} else {
+			rdnsResults[ipStr] = rdnsResult
+		}
+	}
+
+	// populate results
+	for i := range r.Traceroute.Runs {
+		run := &r.Traceroute.Runs[i]
+		if run.Destination.IPAddress != nil {
+			if rdnsResult, exists := rdnsResults[run.Destination.IPAddress.String()]; exists && rdnsResult != nil {
+				run.Destination.ReverseDns = rdnsResult
+			}
+		}
+		for _, hop := range run.Hops {
+			if hop.IPAddress != nil {
+				if rdnsResult, exists := rdnsResults[hop.IPAddress.String()]; exists && rdnsResult != nil {
+					hop.ReverseDns = rdnsResult
+				}
 			}
 		}
 	}

--- a/result/result.go
+++ b/result/result.go
@@ -165,6 +165,10 @@ func (r *Results) normalizeTracerouteHops() {
 }
 
 func (r *Results) normalizeE2eProbe() {
+	if len(r.E2eProbe.RTTs) == 0 {
+		return
+	}
+
 	r.E2eProbe.PacketsSent = len(r.E2eProbe.RTTs)
 
 	// Count received packets (non-zero RTTs) and collect valid RTTs

--- a/result/result.go
+++ b/result/result.go
@@ -203,11 +203,6 @@ func (r *Results) normalizeE2eProbe() {
 		r.E2eProbe.RTT.Avg = totalRTTs / float64(len(validRTTs))
 		r.E2eProbe.RTT.Min = minRTT
 		r.E2eProbe.RTT.Max = maxRTT
-	} else {
-		// No packets received
-		r.E2eProbe.RTT.Avg = 0.0
-		r.E2eProbe.RTT.Min = 0.0
-		r.E2eProbe.RTT.Max = 0.0
 	}
 
 	r.E2eProbe.Jitter = calculateJitter(validRTTs)

--- a/result/result.go
+++ b/result/result.go
@@ -140,6 +140,10 @@ func (r *Results) normalizeTracerouteHops() {
 }
 
 func (r *Results) normalizeTracerouteHopsCount() {
+	if len(r.Traceroute.Runs) == 0 {
+		return
+	}
+
 	var hopCounts []int
 	for _, run := range r.Traceroute.Runs {
 		hopCount := len(run.Hops)

--- a/result/result_test.go
+++ b/result/result_test.go
@@ -37,6 +37,9 @@ func TestResults_Normalize(t *testing.T) {
 						},
 					},
 				},
+				E2eProbe: E2eProbe{
+					RTTs: []float64{20, 30, 40, 0, 30},
+				},
 			},
 			ExpectedResults: Results{
 				Traceroute: Traceroute{
@@ -65,14 +68,15 @@ func TestResults_Normalize(t *testing.T) {
 					},
 				},
 				E2eProbe: E2eProbe{
-					RTTs:                 []float64{30},
-					PacketsSent:          2,
-					PacketsReceived:      1,
-					PacketLossPercentage: 0.5,
+					RTTs:                 []float64{20, 30, 40, 0, 30},
+					PacketsSent:          5,
+					PacketsReceived:      4,
+					PacketLossPercentage: 0.2,
+					Jitter: 10,
 					RTT: E2eProbeRTT{
 						Avg: 30,
-						Min: 30,
-						Max: 30,
+						Min: 20,
+						Max: 40,
 					},
 				},
 			},
@@ -97,6 +101,9 @@ func TestResults_Normalize(t *testing.T) {
 							},
 						},
 					},
+				},
+				E2eProbe: E2eProbe{
+					RTTs: []float64{0, 0, 0, 0, 0},
 				},
 			},
 			ExpectedResults: Results{
@@ -126,11 +133,78 @@ func TestResults_Normalize(t *testing.T) {
 					},
 				},
 				E2eProbe: E2eProbe{
-					RTTs:                 []float64{},
-					PacketsSent:          2,
+					RTTs:                 []float64{0, 0, 0, 0, 0},
+					PacketsSent:          5,
 					PacketsReceived:      0,
 					PacketLossPercentage: 1,
 					RTT:                  E2eProbeRTT{},
+				},
+			},
+		},
+		{
+			name: "only traceroutes",
+			Results: Results{
+				Traceroute: Traceroute{
+					Runs: []TracerouteRun{
+						{
+							Hops: []*TracerouteHop{
+								{IPAddress: net.IP{10, 10, 10, 10}, RTT: 10},
+								{},
+								{IPAddress: net.IP{10, 10, 10, 10}, RTT: 30},
+								{IPAddress: net.IP{10, 10, 10, 10}, RTT: 30, IsDest: true},
+							},
+						},
+					},
+				},
+				E2eProbe: E2eProbe{
+					RTTs: []float64{},
+				},
+			},
+			ExpectedResults: Results{
+				Traceroute: Traceroute{
+					Runs: []TracerouteRun{
+						{
+							RunID: "id-0",
+							Hops: []*TracerouteHop{
+								{IPAddress: net.IP{10, 10, 10, 10}, RTT: 10},
+								{},
+								{IPAddress: net.IP{10, 10, 10, 10}, RTT: 30},
+								{IPAddress: net.IP{10, 10, 10, 10}, RTT: 30, IsDest: true},
+							},
+						},
+					},
+					HopCount: HopCountStats{
+						Avg: 4,
+						Min: 4,
+						Max: 4,
+					},
+				},
+				E2eProbe: E2eProbe{
+					RTTs: []float64{},
+				},
+			},
+		},
+		{
+			name: "only e2e probes",
+			Results: Results{
+				Traceroute: Traceroute{},
+				E2eProbe: E2eProbe{
+					RTTs: []float64{20, 30, 40, 0, 30},
+				},
+			},
+			ExpectedResults: Results{
+				Traceroute: Traceroute{},
+				E2eProbe: E2eProbe{
+					RTTs:                 []float64{20, 30, 40, 0, 30},
+					PacketsSent:          5,
+					PacketsReceived:      4,
+					PacketLossPercentage: 0.2,
+					Jitter: 10,
+					RTT: E2eProbeRTT{
+						Avg: 30,
+						Min: 20,
+						Max: 40,
+					},
 				},
 			},
 		},

--- a/result/result_test.go
+++ b/result/result_test.go
@@ -148,10 +148,10 @@ func TestResults_Normalize(t *testing.T) {
 					Runs: []TracerouteRun{
 						{
 							Hops: []*TracerouteHop{
-								{IPAddress: net.IP{10, 10, 10, 10}, RTT: 10},
+								{IPAddress: net.IP{10, 10, 10, 10}, RTT: 10, Reachable: true},
 								{},
-								{IPAddress: net.IP{10, 10, 10, 10}, RTT: 30},
-								{IPAddress: net.IP{10, 10, 10, 10}, RTT: 30, IsDest: true},
+								{IPAddress: net.IP{10, 10, 10, 10}, RTT: 30, Reachable: true},
+								{IPAddress: net.IP{10, 10, 10, 10}, RTT: 30, IsDest: true, Reachable: true},
 							},
 						},
 					},
@@ -166,10 +166,10 @@ func TestResults_Normalize(t *testing.T) {
 						{
 							RunID: "id-0",
 							Hops: []*TracerouteHop{
-								{IPAddress: net.IP{10, 10, 10, 10}, RTT: 10},
+								{IPAddress: net.IP{10, 10, 10, 10}, RTT: 10, Reachable: true},
 								{},
-								{IPAddress: net.IP{10, 10, 10, 10}, RTT: 30},
-								{IPAddress: net.IP{10, 10, 10, 10}, RTT: 30, IsDest: true},
+								{IPAddress: net.IP{10, 10, 10, 10}, RTT: 30, Reachable: true},
+								{IPAddress: net.IP{10, 10, 10, 10}, RTT: 30, IsDest: true, Reachable: true},
 							},
 						},
 					},

--- a/runner/params.go
+++ b/runner/params.go
@@ -20,4 +20,5 @@ type TracerouteParams struct {
 	TCPSynParisTracerouteMode bool
 	ReverseDns                bool
 	TracerouteQueries         int
+	E2eQueries                int
 }

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -175,7 +175,7 @@ func runTracerouteOnce(ctx context.Context, params TracerouteParams, destination
 func runE2eProbeOnce(ctx context.Context, params TracerouteParams, destinationPort int) (float64, error) {
 	params.MinTTL = params.MaxTTL
 
-	trRun, err := runTracerouteOnce(ctx, params, destinationPort)
+	trRun, err := runTracerouteOnceFn(ctx, params, destinationPort)
 	if err != nil {
 		return 0, err
 	}

--- a/tcp/tcp_traceroute.go
+++ b/tcp/tcp_traceroute.go
@@ -22,7 +22,8 @@ func (t *TCPv4) Traceroute() (*result.TracerouteRun, error) {
 	if err != nil {
 		return nil, fmt.Errorf("TCP Traceroute failed to get local address for target: %w", err)
 	}
-	conn.Close() // we don't need the UDP port here
+	conn.Close() // we don't need the UDP connection here, it was only needed to discover local address
+
 	t.srcIP = addr.IP
 	localAddr, ok := common.UnmappedAddrFromSlice(t.srcIP)
 	if !ok {
@@ -59,7 +60,7 @@ func (t *TCPv4) Traceroute() (*result.TracerouteRun, error) {
 		},
 	})
 	if err != nil {
-		return nil, fmt.Errorf("UDP traceroute failed to set packet filter: %w", err)
+		return nil, fmt.Errorf("TCP traceroute failed to set packet filter: %w", err)
 	}
 
 	driver := newTCPDriver(t, handle.Sink, handle.Source)


### PR DESCRIPTION
Adds end-to-end probe functionality to datadog-traceroute, including running multiple probes (configurable) per test run.  Results include the number of packets sent, packets received, packet loss percentage, latency and jitter.
