### PR TITLE
[icmp] Remove overwrite of MaxTimeout

### DIFF
--- a/icmp/traceroute_icmp.go
+++ b/icmp/traceroute_icmp.go
@@ -56,9 +56,6 @@ func runICMPTraceroute(ctx context.Context, p Params) (*icmpResult, error) {
 		return nil, fmt.Errorf("failed to get local addr: %w", err)
 	}
 	udpConn.Close()
-	deadline := time.Now().Add(p.MaxTimeout())
-	ctx, cancel := context.WithDeadline(ctx, deadline)
-	defer cancel()
 
 	// get this platform's Source and Sink implementations
 	handle, err := packets.NewSourceSink(p.Target)


### PR DESCRIPTION
This PR removes ICMP's `MaxTimeout` logic.

TracerouteParallel already calculates and applies the `MaxTimeout` [located here](https://github.com/DataDog/datadog-traceroute/blob/eda4a556d264e5620a4823d872fba957f854f11f/common/traceroute_parallel.go#L62), so there is no need to modify the `ctx`.