### PR TITLE
Use libpcap which fixes ipv6 on darwin

### DIFF
--- a/packets/bpfdev_darwin.go
+++ b/packets/bpfdev_darwin.go
@@ -11,163 +11,106 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
-	"syscall"
 	"time"
-	"unsafe"
+
+	"github.com/google/gopacket/layers"
+	"github.com/google/gopacket/pcap"
 
 	"github.com/DataDog/datadog-traceroute/common"
-	"github.com/DataDog/datadog-traceroute/log"
-	"golang.org/x/sys/unix"
 )
 
-// Note: the BSD docs say BPF headers are aligned along the machine's word boundary.
-// This isn't true anymore for 64 bit systems, the alignment is still 4 bytes.
-// So it's not aligned by the size of a pointer but rather the alignment of the BpfHdr struct here.
-const bpfSize = int(unsafe.Alignof(unix.BpfHdr{}))
+const (
+	pcapSnapLen    = 4096
+	pcapBufferSize = 1024 * 1024 // 1 MB kernel BPF buffer
+)
 
-func bpfAlign(x int) int {
-	const mask = bpfSize - 1
-	return (x + mask) &^ mask
-}
-
-// maxBpfDevices is the hard limit MacOS has for bpf devices
-const maxBpfDevices = 256
-
-func pickBpfDevice() (int, error) {
-	for i := 0; i < maxBpfDevices; i++ {
-		name := fmt.Sprintf("/dev/bpf%d", i)
-		fd, err := unix.Open(name, unix.O_RDWR, 0)
-		if err == unix.EBUSY {
-			continue
-		}
-		if err != nil {
-			return 0, fmt.Errorf("pickBpfDevice failed to open %s: %w", name, err)
-		}
-
-		return fd, nil
-	}
-
-	return 0, fmt.Errorf("pickBpfDevice tried all %d bpf devices, were all busy", maxBpfDevices)
-}
-
-type BpfDevice struct {
-	fd         int
-	deadline   time.Time
-	readBuf    []byte
-	pktBuf     []byte
+// PcapSource implements the Source interface using libpcap on macOS.
+type PcapSource struct {
+	handle     *pcap.Handle
 	isLoopback bool
+	deadline   time.Time
 }
 
-// Close implements Source.
-func (b *BpfDevice) Close() error {
-	if b.fd == 0 {
-		return nil
-	}
-	fd := b.fd
-	b.fd = 0
-	return unix.Close(fd)
-}
-
-var _ Source = &BpfDevice{}
-
-func (b *BpfDevice) hasNextPacket() bool {
-	return len(b.pktBuf) > 0
-}
+var _ Source = &PcapSource{}
 
 var errNoNewPackets = &common.ReceiveProbeNoPktError{Err: fmt.Errorf("no new packets before timeout")}
 
-func (b *BpfDevice) readPackets() error {
-	timeout := getReadTimeout(b.deadline)
-	tv := syscall.NsecToTimeval(timeout.Nanoseconds())
-	err := syscall.SetBpfTimeout(b.fd, &tv)
-	if err != nil {
-		return fmt.Errorf("readPackets failed toSetBpfTimeout: %w", err)
+// Close implements Source.
+func (p *PcapSource) Close() error {
+	if p.handle != nil {
+		p.handle.Close()
+		p.handle = nil
 	}
-	n, err := unix.Read(b.fd, b.readBuf)
-	if err == unix.EINTR {
-		return errNoNewPackets
-	}
-	if err != nil {
-		return fmt.Errorf("readPackets failed to Read: %w", err)
-	}
-	b.pktBuf = b.readBuf[:n]
-	if n == 0 {
-		return errNoNewPackets
-	}
-
 	return nil
 }
 
-// nextPacket returns the next packet, including ethernet header (but not the darwin BpfHdr)
-func (b *BpfDevice) nextPacket() ([]byte, error) {
-	if len(b.pktBuf) < int(unsafe.Sizeof(unix.BpfHdr{})) {
-		return nil, fmt.Errorf("nextPacket: buffer size=%d is too small", len(b.pktBuf))
-	}
-	header := (*unix.BpfHdr)(unsafe.Pointer(&b.pktBuf[0]))
-	start := int(header.Hdrlen)
-	pktFinish := start + int(header.Caplen)
-	dataFinish := bpfAlign(pktFinish)
-	if len(b.pktBuf) < pktFinish {
-		log.Tracef("CRASHING")
-		return nil, fmt.Errorf("nextPacket: buffer size=%d is smaller than expected size %d", len(b.pktBuf), pktFinish)
-	}
-
-	packet := b.pktBuf[start:pktFinish]
-	if len(b.pktBuf) > dataFinish {
-		b.pktBuf = b.pktBuf[dataFinish:]
-	} else {
-		b.pktBuf = nil
-	}
-
-	return packet, nil
-}
-
-// Read implements Source.
-func (b *BpfDevice) Read(buf []byte) (int, error) {
-	var payload []byte
-	for payload == nil {
-		if !b.hasNextPacket() {
-			err := b.readPackets()
-			if err != nil {
-				return 0, err
-			}
+// Read implements Source. It returns one IP-layer packet (link-layer header stripped).
+func (p *PcapSource) Read(buf []byte) (int, error) {
+	for {
+		if !p.deadline.IsZero() && time.Now().After(p.deadline) {
+			return 0, errNoNewPackets
 		}
 
-		linkFrame, err := b.nextPacket()
+		data, _, err := p.handle.ReadPacketData()
+		if err == pcap.NextErrorTimeoutExpired {
+			if !p.deadline.IsZero() && time.Now().After(p.deadline) {
+				return 0, errNoNewPackets
+			}
+			continue
+		}
 		if err != nil {
-			return 0, err
+			return 0, fmt.Errorf("PcapSource Read failed: %w", err)
 		}
 
-		// BPF returns different link-layer headers depending on interface type:
-		// - Loopback interface (DLT_NULL): 4-byte address family header
-		// - Regular interfaces (DLT_EN10MB): 14-byte Ethernet header
-		if b.isLoopback {
-			// Skip the 4-byte DLT_NULL header to get to the IP packet
-			if len(linkFrame) < 4 {
-				return 0, fmt.Errorf("loopback packet too short: %d bytes", len(linkFrame))
+		var payload []byte
+		if p.isLoopback {
+			if len(data) < 4 {
+				continue
 			}
-			payload = linkFrame[4:]
+			payload = data[4:]
 		} else {
-			payload, err = stripEthernetHeader(linkFrame)
+			payload, err = stripEthernetHeader(data)
 			if err != nil {
 				return 0, err
 			}
+			if payload == nil {
+				continue // non-IP packet, skip
+			}
 		}
-	}
 
-	return copy(buf, payload), nil
+		return copy(buf, payload), nil
+	}
 }
 
 // SetReadDeadline implements Source.
-func (b *BpfDevice) SetReadDeadline(t time.Time) error {
-	b.deadline = t
+func (p *PcapSource) SetReadDeadline(t time.Time) error {
+	p.deadline = t
 	return nil
 }
 
-// SetPacketFilter sets this Source to only return certain packets.
-func (b *BpfDevice) SetPacketFilter(_ PacketFilterSpec) error {
-	// not implemented, no-op on MacOS
-	return nil
+// SetPacketFilter applies a BPF filter expression to the pcap handle.
+func (p *PcapSource) SetPacketFilter(spec PacketFilterSpec) error {
+	expr, err := filterSpecToExpr(spec)
+	if err != nil {
+		return err
+	}
+	return p.handle.SetBPFFilter(expr)
+}
+
+// filterSpecToExpr converts a PacketFilterSpec to a tcpdump filter expression.
+func filterSpecToExpr(spec PacketFilterSpec) (string, error) {
+	switch spec.FilterType {
+	case FilterTypeICMP:
+		return "icmp or icmp6", nil
+	case FilterTypeUDP:
+		return "icmp or icmp6 or udp", nil
+	case FilterTypeTCP:
+		return "icmp or icmp6 or tcp", nil
+	case FilterTypeSYNACK:
+		return "tcp[tcpflags] & tcp-syn != 0 and tcp[tcpflags] & tcp-ack != 0", nil
+	default:
+		return "", fmt.Errorf("unsupported filter type %d", spec.FilterType)
+	}
 }
 
 func deviceForTarget(targetIp netip.Addr) (net.Interface, error) {
@@ -217,32 +160,49 @@ func deviceForTarget(targetIp netip.Addr) (net.Interface, error) {
 	return net.Interface{}, fmt.Errorf("deviceForTarget couldn't find a matching interface")
 }
 
+// NewBpfDevice returns a new Source using libpcap for packet capture.
 func NewBpfDevice(targetIp netip.Addr) (Source, error) {
 	iface, err := deviceForTarget(targetIp)
 	if err != nil {
 		return nil, fmt.Errorf("NewBpfDevice failed to find interface for target: %w", err)
 	}
 
-	fd, err := pickBpfDevice()
+	inactive, err := pcap.NewInactiveHandle(iface.Name)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("NewBpfDevice failed to create pcap handle: %w", err)
 	}
-	err = syscall.SetBpfImmediate(fd, 1)
-	if err != nil {
-		unix.Close(fd)
-		return nil, fmt.Errorf("NewBpfDevice failed to SetBpfImmediate: %w", err)
+	if err := inactive.SetSnapLen(pcapSnapLen); err != nil {
+		inactive.CleanUp()
+		return nil, fmt.Errorf("NewBpfDevice failed to set snap len: %w", err)
+	}
+	if err := inactive.SetPromisc(false); err != nil {
+		inactive.CleanUp()
+		return nil, fmt.Errorf("NewBpfDevice failed to set promisc: %w", err)
+	}
+	if err := inactive.SetTimeout(100 * time.Millisecond); err != nil {
+		inactive.CleanUp()
+		return nil, fmt.Errorf("NewBpfDevice failed to set timeout: %w", err)
+	}
+	if err := inactive.SetBufferSize(pcapBufferSize); err != nil {
+		inactive.CleanUp()
+		return nil, fmt.Errorf("NewBpfDevice failed to set buffer size: %w", err)
 	}
 
-	err = syscall.SetBpfInterface(fd, iface.Name)
+	handle, err := inactive.Activate()
 	if err != nil {
-		unix.Close(fd)
-		return nil, fmt.Errorf("NewBpfDevice failed to SetBpfInterface: %w", err)
+		inactive.CleanUp()
+		return nil, fmt.Errorf("NewBpfDevice failed to activate pcap handle: %w", err)
 	}
 
-	return &BpfDevice{
-		fd:         fd,
-		readBuf:    make([]byte, 4096),
-		pktBuf:     nil, // no packets yet
+	// Verify the link type is something we can handle
+	lt := handle.LinkType()
+	if lt != layers.LinkTypeNull && lt != layers.LinkTypeLoop && lt != layers.LinkTypeEthernet {
+		handle.Close()
+		return nil, fmt.Errorf("NewBpfDevice: unsupported link type %v on %s", lt, iface.Name)
+	}
+
+	return &PcapSource{
+		handle:     handle,
 		isLoopback: iface.Flags&net.FlagLoopback != 0,
 	}, nil
 }

--- a/packets/bpfdev_darwin.go
+++ b/packets/bpfdev_darwin.go
@@ -26,9 +26,9 @@ const (
 
 // PcapSource implements the Source interface using libpcap on macOS.
 type PcapSource struct {
-	handle     *pcap.Handle
-	isLoopback bool
-	deadline   time.Time
+	handle   *pcap.Handle
+	linkType layers.LinkType
+	deadline time.Time
 }
 
 var _ Source = &PcapSource{}
@@ -63,12 +63,13 @@ func (p *PcapSource) Read(buf []byte) (int, error) {
 		}
 
 		var payload []byte
-		if p.isLoopback {
+		switch p.linkType {
+		case layers.LinkTypeNull, layers.LinkTypeLoop:
 			if len(data) < 4 {
 				continue
 			}
 			payload = data[4:]
-		} else {
+		case layers.LinkTypeEthernet:
 			payload, err = stripEthernetHeader(data)
 			if err != nil {
 				return 0, err
@@ -76,6 +77,8 @@ func (p *PcapSource) Read(buf []byte) (int, error) {
 			if payload == nil {
 				continue // non-IP packet, skip
 			}
+		default:
+			return 0, fmt.Errorf("PcapSource Read: unsupported link type %v", p.linkType)
 		}
 
 		return copy(buf, payload), nil
@@ -105,12 +108,24 @@ func filterSpecToExpr(spec PacketFilterSpec) (string, error) {
 	case FilterTypeUDP:
 		return "icmp or icmp6 or udp", nil
 	case FilterTypeTCP:
-		return "icmp or icmp6 or tcp", nil
+		return filterTCPExpr(spec.FilterConfig)
 	case FilterTypeSYNACK:
 		return "tcp[tcpflags] & tcp-syn != 0 and tcp[tcpflags] & tcp-ack != 0", nil
 	default:
 		return "", fmt.Errorf("unsupported filter type %d", spec.FilterType)
 	}
+}
+
+// filterTCPExpr builds a tcpdump expression that passes ICMP/ICMPv6 plus
+// TCP traffic matching the given 4-tuple (src/dst addr+port).
+func filterTCPExpr(cfg FilterConfig) (string, error) {
+	if !cfg.Src.IsValid() || !cfg.Dst.IsValid() {
+		return "", fmt.Errorf("FilterTypeTCP requires valid Src and Dst in FilterConfig")
+	}
+	return fmt.Sprintf(
+		"icmp or icmp6 or (tcp and host %s and host %s and port %d and port %d)",
+		cfg.Src.Addr(), cfg.Dst.Addr(), cfg.Src.Port(), cfg.Dst.Port(),
+	), nil
 }
 
 func deviceForTarget(targetIp netip.Addr) (net.Interface, error) {
@@ -202,7 +217,7 @@ func NewBpfDevice(targetIp netip.Addr) (Source, error) {
 	}
 
 	return &PcapSource{
-		handle:     handle,
-		isLoopback: iface.Flags&net.FlagLoopback != 0,
+		handle:   handle,
+		linkType: handle.LinkType(),
 	}, nil
 }

--- a/packets/frame_parser.go
+++ b/packets/frame_parser.go
@@ -32,7 +32,7 @@ type FrameParser struct {
 }
 
 var ignoredLayerErr = &common.ReceiveProbeNoPktError{
-	Err: fmt.Errorf("FrameParser saw an a layer type not used by traceroute (e.g. SCTP) and decided to ignore it"),
+	Err: fmt.Errorf("FrameParser saw a layer type not used by traceroute (e.g. SCTP) and decided to ignore it"),
 }
 
 const expectedLayerCount = 2

--- a/packets/packet_sink_darwin.go
+++ b/packets/packet_sink_darwin.go
@@ -13,8 +13,10 @@ import (
 	"fmt"
 	"net/netip"
 	"os"
+	"sync"
 	"syscall"
 
+	"golang.org/x/net/ipv6"
 	"golang.org/x/sys/unix"
 )
 
@@ -23,50 +25,81 @@ type sinkDarwin struct {
 	sock     *os.File
 	rawConn  syscall.RawConn
 	writeBuf []byte
+
+	// ipv6Once guards lazy creation of the IPv6 socket. On macOS,
+	// IPPROTO_RAW doesn't support sendmsg with ancillary data, so we
+	// create the socket with the actual transport protocol (NextHeader)
+	// from the first packet.
+	ipv6Once   sync.Once
+	ipv6Proto  int
+	ipv6Err    error
 }
 
 var _ Sink = &sinkDarwin{}
 
 // NewSinkDarwin returns a new sinkDarwin implementing packet sink
 func NewSinkDarwin(addr netip.Addr) (Sink, error) {
-	var domain, protocol int
+	s := &sinkDarwin{
+		writeBuf: make([]byte, 4096),
+	}
+
 	switch {
 	case addr.Is4():
-		domain = unix.AF_INET
-		protocol = unix.IPPROTO_IP
-	case addr.Is6():
-		domain = unix.AF_INET6
-		protocol = unix.IPPROTO_IPV6
-	default:
-		return nil, fmt.Errorf("SinkDarwin supports only IPv4 or IPv6 addresses")
-	}
-
-	fd, err := unix.Socket(domain, unix.SOCK_RAW, unix.IPPROTO_RAW)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create raw socket: %w", err)
-	}
-
-	// darwin only supports IP_HDRINCL for IPv4...
-	if addr.Is4() {
-		err = unix.SetsockoptInt(fd, protocol, unix.IP_HDRINCL, 1)
+		fd, err := unix.Socket(unix.AF_INET, unix.SOCK_RAW, unix.IPPROTO_RAW)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create raw socket: %w", err)
+		}
+		err = unix.SetsockoptInt(fd, unix.IPPROTO_IP, unix.IP_HDRINCL, 1)
 		if err != nil {
 			unix.Close(fd)
 			return nil, fmt.Errorf("failed to set header include option: %w", err)
 		}
+		sock := os.NewFile(uintptr(fd), "")
+		rawConn, err := sock.SyscallConn()
+		if err != nil {
+			sock.Close()
+			return nil, fmt.Errorf("failed to create SyscallConn(): %w", err)
+		}
+		s.sock = sock
+		s.rawConn = rawConn
+	case addr.Is6():
+		// Defer socket creation to WriteTo — macOS does not support
+		// IPPROTO_RAW for IPv6 sendmsg with ancillary data, so we need
+		// the actual transport protocol from the packet's NextHeader field.
+		// Socket created lazily in ensureIPv6Socket.
+	default:
+		return nil, fmt.Errorf("SinkDarwin supports only IPv4 or IPv6 addresses")
 	}
 
-	sock := os.NewFile(uintptr(fd), "")
-	rawConn, err := sock.SyscallConn()
-	if err != nil {
-		sock.Close()
-		return nil, fmt.Errorf("failed to create SyscallConn(): %w", err)
-	}
+	return s, nil
+}
 
-	return &sinkDarwin{
-		sock:     sock,
-		rawConn:  rawConn,
-		writeBuf: make([]byte, 4096),
-	}, nil
+const ipv6HeaderSize = 40
+
+// ensureIPv6Socket lazily creates the IPv6 raw socket using the transport
+// protocol from the IPv6 NextHeader field.
+func (p *sinkDarwin) ensureIPv6Socket(nextHeader int) error {
+	p.ipv6Once.Do(func() {
+		p.ipv6Proto = nextHeader
+		fd, err := unix.Socket(unix.AF_INET6, unix.SOCK_RAW, nextHeader)
+		if err != nil {
+			p.ipv6Err = fmt.Errorf("failed to create IPv6 raw socket (proto %d): %w", nextHeader, err)
+			return
+		}
+		sock := os.NewFile(uintptr(fd), "")
+		rawConn, err := sock.SyscallConn()
+		if err != nil {
+			sock.Close()
+			p.ipv6Err = fmt.Errorf("failed to create SyscallConn(): %w", err)
+			return
+		}
+		p.sock = sock
+		p.rawConn = rawConn
+	})
+	if p.ipv6Err == nil && nextHeader != p.ipv6Proto {
+		return fmt.Errorf("IPv6 socket bound to protocol %d, but got packet with NextHeader %d; only one protocol at a time is supported", p.ipv6Proto, nextHeader)
+	}
+	return p.ipv6Err
 }
 
 // updateNtohs16 replaces network-order uint16 with host-order, in-place
@@ -83,6 +116,7 @@ func (p *sinkDarwin) WriteTo(buf []byte, addr netip.AddrPort) error {
 	}
 
 	var sendBuf []byte
+	var oob []byte
 	switch {
 	case addr.Addr().Is4():
 		if len(buf) > len(p.writeBuf) {
@@ -103,29 +137,34 @@ func (p *sinkDarwin) WriteTo(buf []byte, addr netip.AddrPort) error {
 		updateNtohs16(sendBuf[ip_lenOffset : ip_lenOffset+2])
 		updateNtohs16(sendBuf[ip_offOffset : ip_offOffset+2])
 	case addr.Addr().Is6():
+		if len(buf) < ipv6HeaderSize {
+			return fmt.Errorf("sinkDarwin WriteTo: packet too small for IPv6 header")
+		}
+		// Read NextHeader before stripping, so we can create the right socket
+		nextHeader := int(buf[6])
+		if err := p.ensureIPv6Socket(nextHeader); err != nil {
+			return err
+		}
 		// IPv6: darwin has no IPV6_HDRINCL, so we need to strip the IPv6 header
 		var ttl uint8
 		sendBuf, ttl, err = stripIPv6Header(buf)
 		if err != nil {
 			return fmt.Errorf("failed to strip IPv6 header: %w", err)
 		}
-		var controlErr error
-		// set the TTL via IPV6_HOPLIMIT
-		err = p.rawConn.Control(func(fd uintptr) {
-			controlErr = unix.SetsockoptInt(int(fd), unix.IPPROTO_IPV6, unix.IPV6_HOPLIMIT, int(ttl))
-		})
-		if err != nil {
-			return fmt.Errorf("failed to call Control() for IPV6_HOPLIMIT: %w", controlErr)
+		control := ipv6.ControlMessage{
+			HopLimit: int(ttl),
 		}
-		if controlErr != nil {
-			return fmt.Errorf("failed to set IPV6_HOPLIMIT: %w", controlErr)
-		}
+		oob = control.Marshal()
 	default:
 		return fmt.Errorf("invalid address family %s", addr)
 	}
 
 	writeErr := p.rawConn.Write(func(fd uintptr) bool {
-		err = unix.Sendto(int(fd), sendBuf, 0, sa)
+		if oob != nil {
+			err = unix.Sendmsg(int(fd), sendBuf, oob, sa, 0)
+		} else {
+			err = unix.Sendto(int(fd), sendBuf, 0, sa)
+		}
 		if err == nil {
 			return true
 		}
@@ -138,5 +177,8 @@ func (p *sinkDarwin) WriteTo(buf []byte, addr netip.AddrPort) error {
 
 // Close closes the socket
 func (p *sinkDarwin) Close() error {
-	return p.sock.Close()
+	if p.sock != nil {
+		return p.sock.Close()
+	}
+	return nil
 }

--- a/packets/pcap_filter_test.go
+++ b/packets/pcap_filter_test.go
@@ -1,0 +1,91 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build test && !windows && root
+
+package packets
+
+import (
+	"bufio"
+	"net"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/google/gopacket/layers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-traceroute/common"
+	"github.com/DataDog/datadog-traceroute/testutils"
+)
+
+func newTestSource(t *testing.T) Source {
+	t.Helper()
+	handle, err := NewSourceSink(netip.MustParseAddr("127.0.0.1"), false)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		handle.Source.Close()
+		handle.Sink.Close()
+	})
+	return handle.Source
+}
+
+func doTCPExchange(t *testing.T) {
+	t.Helper()
+	server := testutils.NewTCPServerOnAddress("127.0.0.1:0", func(c net.Conn) {
+		r := bufio.NewReader(c)
+		r.ReadBytes(byte('\n'))
+		c.Write([]byte("pong\n"))
+		testutils.GracefulCloseTCP(c)
+	})
+	t.Cleanup(server.Shutdown)
+	require.NoError(t, server.Listen())
+	server.StartAccepting()
+
+	conn, err := net.Dial("tcp", server.Address())
+	require.NoError(t, err)
+	conn.Write([]byte("ping\n"))
+	r := bufio.NewReader(conn)
+	r.ReadBytes(byte('\n'))
+	testutils.GracefulCloseTCP(conn)
+}
+
+func TestFilterICMPBlocksTCP(t *testing.T) {
+	source := newTestSource(t)
+
+	err := source.SetPacketFilter(PacketFilterSpec{FilterType: FilterTypeICMP})
+	require.NoError(t, err)
+
+	doTCPExchange(t)
+
+	buf := make([]byte, 4096)
+	source.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+	_, err = source.Read(buf)
+
+	var noPkt *common.ReceiveProbeNoPktError
+	assert.ErrorAs(t, err, &noPkt,
+		"expected timeout (TCP should be filtered by ICMP filter), got: %v", err)
+}
+
+func TestFilterICMPPassesICMP(t *testing.T) {
+	source := newTestSource(t)
+
+	err := source.SetPacketFilter(PacketFilterSpec{FilterType: FilterTypeICMP})
+	require.NoError(t, err)
+
+	// Send UDP to a closed port to trigger ICMP Port Unreachable
+	conn, err := net.Dial("udp", "127.0.0.1:19234")
+	require.NoError(t, err)
+	conn.Write([]byte("hello"))
+	conn.Close()
+
+	buf := make([]byte, 4096)
+	parser := NewFrameParser()
+	source.SetReadDeadline(time.Now().Add(2 * time.Second))
+	err = ReadAndParse(source, buf, parser)
+	require.NoError(t, err, "expected to capture ICMP packet")
+	assert.Equal(t, layers.LayerTypeICMPv4, parser.GetTransportLayer())
+}

--- a/packets/pcap_filter_test.go
+++ b/packets/pcap_filter_test.go
@@ -24,7 +24,7 @@ import (
 
 func newTestSource(t *testing.T) Source {
 	t.Helper()
-	handle, err := NewSourceSink(netip.MustParseAddr("127.0.0.1"), false)
+	handle, err := NewSourceSink(netip.MustParseAddr("127.0.0.1"), true)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		handle.Source.Close()
@@ -37,8 +37,10 @@ func doTCPExchange(t *testing.T) {
 	t.Helper()
 	server := testutils.NewTCPServerOnAddress("127.0.0.1:0", func(c net.Conn) {
 		r := bufio.NewReader(c)
-		r.ReadBytes(byte('\n'))
-		c.Write([]byte("pong\n"))
+		_, err := r.ReadBytes(byte('\n'))
+		require.NoError(t, err)
+		_, err = c.Write([]byte("pong\n"))
+		require.NoError(t, err)
 		testutils.GracefulCloseTCP(c)
 	})
 	t.Cleanup(server.Shutdown)
@@ -47,9 +49,11 @@ func doTCPExchange(t *testing.T) {
 
 	conn, err := net.Dial("tcp", server.Address())
 	require.NoError(t, err)
-	conn.Write([]byte("ping\n"))
+	_, err = conn.Write([]byte("ping\n"))
+	require.NoError(t, err)
 	r := bufio.NewReader(conn)
-	r.ReadBytes(byte('\n'))
+	_, err = r.ReadBytes(byte('\n'))
+	require.NoError(t, err)
 	testutils.GracefulCloseTCP(conn)
 }
 
@@ -62,7 +66,7 @@ func TestFilterICMPBlocksTCP(t *testing.T) {
 	doTCPExchange(t)
 
 	buf := make([]byte, 4096)
-	source.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+	require.NoError(t, source.SetReadDeadline(time.Now().Add(500*time.Millisecond)))
 	_, err = source.Read(buf)
 
 	var noPkt *common.ReceiveProbeNoPktError
@@ -79,12 +83,13 @@ func TestFilterICMPPassesICMP(t *testing.T) {
 	// Send UDP to a closed port to trigger ICMP Port Unreachable
 	conn, err := net.Dial("udp", "127.0.0.1:19234")
 	require.NoError(t, err)
-	conn.Write([]byte("hello"))
-	conn.Close()
+	_, err = conn.Write([]byte("hello"))
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
 
 	buf := make([]byte, 4096)
 	parser := NewFrameParser()
-	source.SetReadDeadline(time.Now().Add(2 * time.Second))
+	require.NoError(t, source.SetReadDeadline(time.Now().Add(2*time.Second)))
 	err = ReadAndParse(source, buf, parser)
 	require.NoError(t, err, "expected to capture ICMP packet")
 	assert.Equal(t, layers.LayerTypeICMPv4, parser.GetTransportLayer())

--- a/udp/udp_driver.go
+++ b/udp/udp_driver.go
@@ -188,7 +188,7 @@ func (u *udpDriver) handleProbeLayers() (*common.ProbeResponse, error) {
 		TTL:    probe.ttl,
 		IP:     ipPair.SrcAddr,
 		RTT:    rtt,
-		IsDest: ipPair.SrcAddr == u.getTargetAddrPort().Addr(),
+		IsDest: u.parser.IsDestinationUnreachable() || ipPair.SrcAddr == u.getTargetAddrPort().Addr(),
 	}, nil
 }
 

--- a/udp/udp_driver.go
+++ b/udp/udp_driver.go
@@ -188,7 +188,7 @@ func (u *udpDriver) handleProbeLayers() (*common.ProbeResponse, error) {
 		TTL:    probe.ttl,
 		IP:     ipPair.SrcAddr,
 		RTT:    rtt,
-		IsDest: u.parser.IsDestinationUnreachable() || ipPair.SrcAddr == u.getTargetAddrPort().Addr(),
+		IsDest: ipPair.SrcAddr == u.getTargetAddrPort().Addr(),
 	}, nil
 }
 


### PR DESCRIPTION
Before this PR, darwin's packet source has been using raw syscalls (and hasn't supported BPF filtering). Jack pointed out darwin ships with libpcap so we can use it without having to bundle any dynamic libraries.  This is much preferred over doing the syscalls yourself so I'm switching this over.  In the process this also fixes ipv6 traceroutes on darwin which is great.

## Verification
I added `packets/pcap_filter_test.go` which should test our bpf filtering on every platform.  It requires root, so I ran it locally.