### PR TITLE
fix: 🔒 bump Go toolchain to 1.26.4 (CVE-2026-42504)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/DataDog/datadog-traceroute
 
 go 1.25.6
 
-toolchain go1.26.2
+toolchain go1.26.4
 
 require (
 	github.com/DataDog/datadog-agent/pkg/network/driver v0.81.0-devel.0.20260603133502-a41610237dba


### PR DESCRIPTION
## What

Bump the `go.mod` toolchain directive from `go1.26.2` → `go1.26.4`.

## Why

The synthetics-worker PROD Grype scan flagged **CVE-2026-42504** (High) in the Go `stdlib`, fixed in **≥1.25.11 or ≥1.26.4**.

While `.go-version` is already `1.25.11` (patched), the `go.mod` `toolchain go1.26.2` directive forces builds *up* to 1.26.2 on any runner — which is **< 1.26.4** and therefore still vulnerable on the 1.26.x line. Bumping the toolchain to `go1.26.4` ensures the released binary is built with a patched stdlib.

`golang.org/x/net` is already at `v0.55.0` (covers CVE-2026-39821 + CVE-2026-33814), so no dependency change is needed here.

## Verification

- `go build ./...` ✅ (GOTOOLCHAIN=go1.26.4)
- `go test ./...` ✅ all packages pass

## Follow-up

Once this is released, the synthetics-worker `TRACEROUTE_VERSION` pin (currently 1.0.17) should be bumped to the new release to ship the patched binary.