### PR TITLE
Fix macOS pcap traceroute ~100 ms latency floor

### DIFF
--- a/packets/bpfdev_darwin.go
+++ b/packets/bpfdev_darwin.go
@@ -20,8 +20,9 @@ import (
 )
 
 const (
-	pcapSnapLen    = 4096
-	pcapBufferSize = 1024 * 1024 // 1 MB kernel BPF buffer
+	pcapSnapLen     = 4096
+	pcapReadTimeout = 100 * time.Millisecond
+	pcapBufferSize  = 1024 * 1024 // 1 MB kernel BPF buffer
 )
 
 // PcapSource implements the Source interface using libpcap on macOS.
@@ -194,9 +195,13 @@ func NewBpfDevice(targetIp netip.Addr) (Source, error) {
 		inactive.CleanUp()
 		return nil, fmt.Errorf("NewBpfDevice failed to set promisc: %w", err)
 	}
-	if err := inactive.SetTimeout(100 * time.Millisecond); err != nil {
+	if err := inactive.SetTimeout(pcapReadTimeout); err != nil {
 		inactive.CleanUp()
 		return nil, fmt.Errorf("NewBpfDevice failed to set timeout: %w", err)
+	}
+	if err := inactive.SetImmediateMode(true); err != nil {
+		inactive.CleanUp()
+		return nil, fmt.Errorf("NewBpfDevice failed to set immediate mode: %w", err)
 	}
 	if err := inactive.SetBufferSize(pcapBufferSize); err != nil {
 		inactive.CleanUp()

--- a/packets/bpfdev_darwin_test.go
+++ b/packets/bpfdev_darwin_test.go
@@ -54,7 +54,6 @@ func TestPcapSourceDeliversPacketsWithoutReadTimeoutDelay(t *testing.T) {
 	buf := make([]byte, 4096)
 	parser := NewFrameParser()
 	readResult := make(chan error, 1)
-	start := time.Now()
 	go func() {
 		if err := source.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
 			readResult <- err
@@ -63,6 +62,7 @@ func TestPcapSourceDeliversPacketsWithoutReadTimeoutDelay(t *testing.T) {
 		readResult <- ReadAndParse(source, buf, parser)
 	}()
 
+	start := time.Now()
 	conn, err := net.Dial("tcp", listener.Addr().String())
 	require.NoError(t, err)
 	require.NoError(t, conn.Close())
@@ -79,5 +79,5 @@ func TestPcapSourceDeliversPacketsWithoutReadTimeoutDelay(t *testing.T) {
 	assert.Equal(t, layers.LayerTypeTCP, parser.GetTransportLayer())
 	assert.True(t, parser.TCP.SYN)
 	assert.True(t, parser.TCP.ACK)
-	assert.Less(t, elapsed, 75*time.Millisecond, "pcap should deliver packets before the 100ms read timeout")
+	assert.Less(t, elapsed, pcapReadTimeout*3/4, "pcap should deliver packets before the read timeout")
 }

--- a/packets/bpfdev_darwin_test.go
+++ b/packets/bpfdev_darwin_test.go
@@ -1,0 +1,83 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build test && darwin && root
+
+package packets
+
+import (
+	"net"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/google/gopacket/layers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestSourceForLoopback() (Source, func() error, error) {
+	source, err := NewBpfDevice(netip.MustParseAddr("127.0.0.1"))
+	if err != nil {
+		return nil, nil, err
+	}
+	return source, source.Close, nil
+}
+
+func TestPcapSourceDeliversPacketsWithoutReadTimeoutDelay(t *testing.T) {
+	source, err := NewBpfDevice(netip.MustParseAddr("127.0.0.1"))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, source.Close())
+	})
+
+	require.NoError(t, source.SetPacketFilter(PacketFilterSpec{FilterType: FilterTypeSYNACK}))
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = listener.Close()
+	})
+
+	acceptErr := make(chan error, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			acceptErr <- err
+			return
+		}
+		acceptErr <- conn.Close()
+	}()
+
+	buf := make([]byte, 4096)
+	parser := NewFrameParser()
+	readResult := make(chan error, 1)
+	start := time.Now()
+	go func() {
+		if err := source.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+			readResult <- err
+			return
+		}
+		readResult <- ReadAndParse(source, buf, parser)
+	}()
+
+	conn, err := net.Dial("tcp", listener.Addr().String())
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+
+	select {
+	case err := <-readResult:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for packet capture")
+	}
+	elapsed := time.Since(start)
+
+	require.NoError(t, <-acceptErr)
+	assert.Equal(t, layers.LayerTypeTCP, parser.GetTransportLayer())
+	assert.True(t, parser.TCP.SYN)
+	assert.True(t, parser.TCP.ACK)
+	assert.Less(t, elapsed, 75*time.Millisecond, "pcap should deliver packets before the 100ms read timeout")
+}

--- a/packets/bpfdev_darwin_test.go
+++ b/packets/bpfdev_darwin_test.go
@@ -40,6 +40,7 @@ func TestPcapSourceDeliversPacketsWithoutReadTimeoutDelay(t *testing.T) {
 	t.Cleanup(func() {
 		_ = listener.Close()
 	})
+	listenerPort := layers.TCPPort(listener.Addr().(*net.TCPAddr).Port)
 
 	acceptErr := make(chan error, 1)
 	go func() {
@@ -59,7 +60,19 @@ func TestPcapSourceDeliversPacketsWithoutReadTimeoutDelay(t *testing.T) {
 			readResult <- err
 			return
 		}
-		readResult <- ReadAndParse(source, buf, parser)
+		for {
+			if err := ReadAndParse(source, buf, parser); err != nil {
+				readResult <- err
+				return
+			}
+			if parser.GetTransportLayer() == layers.LayerTypeTCP &&
+				parser.TCP.SYN &&
+				parser.TCP.ACK &&
+				parser.TCP.SrcPort == listenerPort {
+				readResult <- nil
+				return
+			}
+		}
 	}()
 
 	start := time.Now()
@@ -79,5 +92,6 @@ func TestPcapSourceDeliversPacketsWithoutReadTimeoutDelay(t *testing.T) {
 	assert.Equal(t, layers.LayerTypeTCP, parser.GetTransportLayer())
 	assert.True(t, parser.TCP.SYN)
 	assert.True(t, parser.TCP.ACK)
+	assert.Equal(t, listenerPort, parser.TCP.SrcPort)
 	assert.Less(t, elapsed, pcapReadTimeout*3/4, "pcap should deliver packets before the read timeout")
 }

--- a/packets/pcap_filter_test.go
+++ b/packets/pcap_filter_test.go
@@ -10,7 +10,6 @@ package packets
 import (
 	"bufio"
 	"net"
-	"net/netip"
 	"testing"
 	"time"
 
@@ -24,13 +23,12 @@ import (
 
 func newTestSource(t *testing.T) Source {
 	t.Helper()
-	handle, err := NewSourceSink(netip.MustParseAddr("127.0.0.1"), true)
+	source, closeSource, err := newTestSourceForLoopback()
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		handle.Source.Close()
-		handle.Sink.Close()
+		require.NoError(t, closeSource())
 	})
-	return handle.Source
+	return source
 }
 
 func doTCPExchange(t *testing.T) {

--- a/packets/test_source_notdarwin_test.go
+++ b/packets/test_source_notdarwin_test.go
@@ -1,0 +1,23 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build test && !darwin && !windows && root
+
+package packets
+
+import (
+	"errors"
+	"net/netip"
+)
+
+func newTestSourceForLoopback() (Source, func() error, error) {
+	handle, err := NewSourceSink(netip.MustParseAddr("127.0.0.1"), true)
+	if err != nil {
+		return nil, nil, err
+	}
+	return handle.Source, func() error {
+		return errors.Join(handle.Source.Close(), handle.Sink.Close())
+	}, nil
+}


### PR DESCRIPTION
## Summary

Fixes #133.

On macOS, libpcap/BPF capture was configured with a 100 ms read timeout but not immediate mode. In practice, captured packets could be delivered to userspace on that timeout cadence, so traceroute RTT accounting included capture delivery delay. This produced an artificial ~100 ms RTT floor, including for directly reachable LAN targets.

This PR enables pcap immediate mode for the macOS BPF source so packets are delivered as soon as they arrive, while keeping the existing timeout as a fallback/read timeout setting.

## Changes

- Enables `InactiveHandle.SetImmediateMode(true)` in the Darwin pcap source before activation.
- Names the existing pcap read timeout constant for clarity.
- Adds a Darwin/root tagged regression test that captures a localhost TCP SYN/ACK and asserts delivery happens before the old 100 ms timeout floor.
- Adjusts root-tagged packet test helpers so macOS capture-only tests use `NewBpfDevice` directly instead of requiring an unused raw packet sink.

## Validation

Reproduced before the fix:

- `datadog-traceroute` reported ~101-105 ms RTT to a local gateway over TCP/80.
- Independent `curl` TCP connect timing to the same gateway was ~5 ms.
- `tcpdump -ttt` showed SYN to SYN/ACK at ~3 ms.

Checks run after the fix:

```bash
go test -tags 'test root' ./packets -run TestPcapSourceDeliversPacketsWithoutReadTimeoutDelay -count=10 -v
go test -tags 'test root' ./packets -count=1 -v
go test ./...
make build
```

All passed.

## Risk

Scoped to macOS packet capture setup. Linux uses AF_PACKET and Windows uses raw socket/driver completion paths, so this does not change their capture behavior.

## Follow-up

This PR intentionally keeps the fix scoped to immediate mode plus regression coverage. Timestamp-based RTT accounting with packet capture metadata is broader hardening and is tracked separately in #135.