### PR TITLE
Use packet capture timestamps for RTT accounting

### DIFF
--- a/icmp/icmp_driver.go
+++ b/icmp/icmp_driver.go
@@ -132,13 +132,14 @@ func (s *icmpDriver) ReceiveProbe(timeout time.Duration) (*common.ProbeResponse,
 	if err != nil {
 		return nil, fmt.Errorf("icmpDriver failed to SetReadDeadline: %w", err)
 	}
-	if err := packets.ReadAndParse(s.source, s.buffer, s.parser); err != nil {
+	receivedAt, err := packets.ReadAndParse(s.source, s.buffer, s.parser)
+	if err != nil {
 		return nil, err
 	}
-	return s.handleProbeLayers(s.parser)
+	return s.handleProbeLayers(s.parser, receivedAt)
 }
 
-func (s *icmpDriver) getRTTFromRelSeq(relSeq uint8) (time.Duration, error) {
+func (s *icmpDriver) getRTTFromRelSeq(relSeq uint8, receivedAt time.Time) (time.Duration, error) {
 	if relSeq < s.params.ParallelParams.MinTTL || relSeq > s.params.ParallelParams.MaxTTL {
 		return 0, fmt.Errorf("getRTTFromRelSeq: invalid relative sequence number %d", relSeq)
 	}
@@ -146,12 +147,12 @@ func (s *icmpDriver) getRTTFromRelSeq(relSeq uint8) (time.Duration, error) {
 	if !ok || t.IsZero() {
 		return 0, fmt.Errorf("getRTTFromRelSeq: no probe sent for relative sequence number %d", relSeq)
 	}
-	return time.Since(t), nil
+	return receivedAt.Sub(t), nil
 }
 
 var errPacketDidNotMatchTraceroute = &common.ReceiveProbeNoPktError{Err: fmt.Errorf("packet did not match the traceroute")}
 
-func (s *icmpDriver) handleProbeLayers(parser *packets.FrameParser) (*common.ProbeResponse, error) {
+func (s *icmpDriver) handleProbeLayers(parser *packets.FrameParser, receivedAt time.Time) (*common.ProbeResponse, error) {
 	ipPair, err := parser.GetIPPair()
 	if err != nil {
 		return nil, fmt.Errorf("icmpDriver failed to get IP pair: %w", err)
@@ -187,7 +188,7 @@ func (s *icmpDriver) handleProbeLayers(parser *packets.FrameParser) (*common.Pro
 			if uint16(echo.ID) != s.echoID {
 				return nil, &common.BadPacketError{Err: fmt.Errorf("mismatched echo ID")}
 			}
-			rtt, err := s.getRTTFromRelSeq(uint8(echo.Seq))
+			rtt, err := s.getRTTFromRelSeq(uint8(echo.Seq), receivedAt)
 			if err != nil {
 				return nil, &common.BadPacketError{Err: fmt.Errorf("icmpDriver failed to get RTT: %w", err)}
 			}
@@ -201,7 +202,7 @@ func (s *icmpDriver) handleProbeLayers(parser *packets.FrameParser) (*common.Pro
 			if parser.ICMP4.Id != s.echoID {
 				return nil, &common.BadPacketError{Err: fmt.Errorf("mismatched echo ID")}
 			}
-			rtt, err := s.getRTTFromRelSeq(uint8(parser.ICMP4.Seq))
+			rtt, err := s.getRTTFromRelSeq(uint8(parser.ICMP4.Seq), receivedAt)
 			if err != nil {
 				return nil, &common.BadPacketError{Err: fmt.Errorf("icmpDriver failed to get RTT: %w", err)}
 			}
@@ -242,7 +243,7 @@ func (s *icmpDriver) handleProbeLayers(parser *packets.FrameParser) (*common.Pro
 			if echo.Identifier != s.echoID {
 				return nil, &common.BadPacketError{Err: fmt.Errorf("mismatched echo ID")}
 			}
-			rtt, err := s.getRTTFromRelSeq(uint8(echo.SeqNumber))
+			rtt, err := s.getRTTFromRelSeq(uint8(echo.SeqNumber), receivedAt)
 			if err != nil {
 				return nil, &common.BadPacketError{Err: fmt.Errorf("icmpDriver failed to get RTT: %w", err)}
 			}
@@ -262,7 +263,7 @@ func (s *icmpDriver) handleProbeLayers(parser *packets.FrameParser) (*common.Pro
 			if id != s.echoID {
 				return nil, &common.BadPacketError{Err: fmt.Errorf("mismatched echo ID")}
 			}
-			rtt, err := s.getRTTFromRelSeq(uint8(seq))
+			rtt, err := s.getRTTFromRelSeq(uint8(seq), receivedAt)
 			if err != nil {
 				return nil, &common.BadPacketError{Err: fmt.Errorf("icmpDriver failed to get RTT: %w", err)}
 			}

--- a/icmp/icmp_driver.go
+++ b/icmp/icmp_driver.go
@@ -147,7 +147,7 @@ func (s *icmpDriver) getRTTFromRelSeq(relSeq uint8, receivedAt time.Time) (time.
 	if !ok || t.IsZero() {
 		return 0, fmt.Errorf("getRTTFromRelSeq: no probe sent for relative sequence number %d", relSeq)
 	}
-	return receivedAt.Sub(t), nil
+	return packets.RTT(receivedAt, t), nil
 }
 
 var errPacketDidNotMatchTraceroute = &common.ReceiveProbeNoPktError{Err: fmt.Errorf("packet did not match the traceroute")}

--- a/packets/bpfdev_darwin.go
+++ b/packets/bpfdev_darwin.go
@@ -27,9 +27,16 @@ const (
 
 // PcapSource implements the Source interface using libpcap on macOS.
 type PcapSource struct {
-	handle   *pcap.Handle
-	linkType layers.LinkType
-	deadline time.Time
+	handle       *pcap.Handle
+	linkType     layers.LinkType
+	deadline     time.Time
+	lastKernelTS time.Time
+}
+
+// LastPacketTimestamp implements TimestampedSource. It returns the kernel/BPF
+// capture timestamp of the most recently read packet.
+func (p *PcapSource) LastPacketTimestamp() (time.Time, bool) {
+	return p.lastKernelTS, !p.lastKernelTS.IsZero()
 }
 
 var _ Source = &PcapSource{}
@@ -52,7 +59,10 @@ func (p *PcapSource) Read(buf []byte) (int, error) {
 			return 0, errNoNewPackets
 		}
 
-		data, _, err := p.handle.ReadPacketData()
+		data, ci, err := p.handle.ReadPacketData()
+		if err == nil {
+			p.lastKernelTS = ci.Timestamp
+		}
 		if err == pcap.NextErrorTimeoutExpired {
 			if !p.deadline.IsZero() && time.Now().After(p.deadline) {
 				return 0, errNoNewPackets

--- a/packets/bpfdev_darwin.go
+++ b/packets/bpfdev_darwin.go
@@ -40,6 +40,7 @@ func (p *PcapSource) LastPacketTimestamp() (time.Time, bool) {
 }
 
 var _ Source = &PcapSource{}
+var _ TimestampedSource = &PcapSource{}
 
 var errNoNewPackets = &common.ReceiveProbeNoPktError{Err: fmt.Errorf("no new packets before timeout")}
 

--- a/packets/bpfdev_darwin_test.go
+++ b/packets/bpfdev_darwin_test.go
@@ -54,22 +54,27 @@ func TestPcapSourceDeliversPacketsWithoutReadTimeoutDelay(t *testing.T) {
 
 	buf := make([]byte, 4096)
 	parser := NewFrameParser()
-	readResult := make(chan error, 1)
+	type readOutcome struct {
+		receivedAt time.Time
+		err        error
+	}
+	readResult := make(chan readOutcome, 1)
 	go func() {
 		if err := source.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
-			readResult <- err
+			readResult <- readOutcome{err: err}
 			return
 		}
 		for {
-			if _, err := ReadAndParse(source, buf, parser); err != nil {
-				readResult <- err
+			receivedAt, err := ReadAndParse(source, buf, parser)
+			if err != nil {
+				readResult <- readOutcome{err: err}
 				return
 			}
 			if parser.GetTransportLayer() == layers.LayerTypeTCP &&
 				parser.TCP.SYN &&
 				parser.TCP.ACK &&
 				parser.TCP.SrcPort == listenerPort {
-				readResult <- nil
+				readResult <- readOutcome{receivedAt: receivedAt}
 				return
 			}
 		}
@@ -80,9 +85,11 @@ func TestPcapSourceDeliversPacketsWithoutReadTimeoutDelay(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, conn.Close())
 
+	var receivedAt time.Time
 	select {
-	case err := <-readResult:
-		require.NoError(t, err)
+	case outcome := <-readResult:
+		require.NoError(t, outcome.err)
+		receivedAt = outcome.receivedAt
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for packet capture")
 	}
@@ -94,4 +101,13 @@ func TestPcapSourceDeliversPacketsWithoutReadTimeoutDelay(t *testing.T) {
 	assert.True(t, parser.TCP.ACK)
 	assert.Equal(t, listenerPort, parser.TCP.SrcPort)
 	assert.Less(t, elapsed, pcapReadTimeout*3/4, "pcap should deliver packets before the read timeout")
+
+	// Assert that the timestamp ReadAndParse returns for this packet actually came from
+	// PcapSource's kernel/BPF capture timestamp, not a userspace time.Now() fallback --
+	// this is the real production wiring, unlike the fake TimestampedSource used in
+	// packet_source_test.go, so it guards against PcapSource silently losing its
+	// LastPacketTimestamp implementation.
+	require.False(t, receivedAt.IsZero(), "expected a non-zero capture timestamp from PcapSource")
+	assert.False(t, receivedAt.Before(start), "capture timestamp should not predate the connection attempt")
+	assert.False(t, receivedAt.After(start.Add(elapsed)), "capture timestamp should not be after the packet was observed by the test")
 }

--- a/packets/bpfdev_darwin_test.go
+++ b/packets/bpfdev_darwin_test.go
@@ -61,7 +61,7 @@ func TestPcapSourceDeliversPacketsWithoutReadTimeoutDelay(t *testing.T) {
 			return
 		}
 		for {
-			if err := ReadAndParse(source, buf, parser); err != nil {
+			if _, err := ReadAndParse(source, buf, parser); err != nil {
 				readResult <- err
 				return
 			}

--- a/packets/packet_source.go
+++ b/packets/packet_source.go
@@ -31,23 +31,40 @@ type Source interface {
 	SetPacketFilter(spec PacketFilterSpec) error
 }
 
-// ReadAndParse reads from the given source into the buffer, and parses it with parser
-func ReadAndParse(source Source, buffer []byte, parser *FrameParser) error {
+// TimestampedSource is implemented by Sources that can report a kernel-provided
+// capture timestamp for the most recently read packet, which is more accurate
+// than a userspace time.Now() taken after Read() returns.
+type TimestampedSource interface {
+	// LastPacketTimestamp returns the kernel timestamp of the most recently
+	// read packet, if available.
+	LastPacketTimestamp() (time.Time, bool)
+}
+
+// ReadAndParse reads from the given source into the buffer, and parses it with parser.
+// It returns the time the packet was received, preferring a kernel-provided
+// timestamp (via TimestampedSource) over a userspace time.Now() when available.
+func ReadAndParse(source Source, buffer []byte, parser *FrameParser) (time.Time, error) {
 	n, err := source.Read(buffer)
 	if errors.Is(err, os.ErrDeadlineExceeded) {
-		return &common.ReceiveProbeNoPktError{Err: err}
+		return time.Time{}, &common.ReceiveProbeNoPktError{Err: err}
 	}
 	if err != nil {
-		return fmt.Errorf("ConnHandle failed to Read: %w", err)
+		return time.Time{}, fmt.Errorf("ConnHandle failed to Read: %w", err)
 	}
 	if n == 0 {
-		return fmt.Errorf("ConnHandle Read() returned 0 bytes")
+		return time.Time{}, fmt.Errorf("ConnHandle Read() returned 0 bytes")
 	}
 
-	err = parser.Parse(buffer[:n])
-	if err != nil {
-		return err
+	receivedAt := time.Now()
+	if ts, ok := source.(TimestampedSource); ok {
+		if kernelTime, ok := ts.LastPacketTimestamp(); ok {
+			receivedAt = kernelTime
+		}
 	}
 
-	return nil
+	if err := parser.Parse(buffer[:n]); err != nil {
+		return time.Time{}, err
+	}
+
+	return receivedAt, nil
 }

--- a/packets/packet_source.go
+++ b/packets/packet_source.go
@@ -49,10 +49,10 @@ func ReadAndParse(source Source, buffer []byte, parser *FrameParser) (time.Time,
 		return time.Time{}, &common.ReceiveProbeNoPktError{Err: err}
 	}
 	if err != nil {
-		return time.Time{}, fmt.Errorf("ConnHandle failed to Read: %w", err)
+		return time.Time{}, fmt.Errorf("Source failed to Read: %w", err)
 	}
 	if n == 0 {
-		return time.Time{}, fmt.Errorf("ConnHandle Read() returned 0 bytes")
+		return time.Time{}, fmt.Errorf("Source Read() returned 0 bytes")
 	}
 
 	receivedAt := time.Now()

--- a/packets/packet_source.go
+++ b/packets/packet_source.go
@@ -68,3 +68,16 @@ func ReadAndParse(source Source, buffer []byte, parser *FrameParser) (time.Time,
 
 	return receivedAt, nil
 }
+
+// RTT computes the round-trip time for a probe sent at sendTime, given the
+// receivedAt timestamp returned by ReadAndParse. A kernel-provided capture
+// timestamp carries no monotonic clock reading, so it isn't protected against
+// the system wall clock stepping backward between sendTime and receivedAt. If
+// that happens, receivedAt could predate sendTime and yield a negative RTT;
+// in that case we fall back to measuring against the current time instead.
+func RTT(receivedAt, sendTime time.Time) time.Duration {
+	if receivedAt.Before(sendTime) {
+		return time.Since(sendTime)
+	}
+	return receivedAt.Sub(sendTime)
+}

--- a/packets/packet_source_test.go
+++ b/packets/packet_source_test.go
@@ -1,0 +1,107 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package packets
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+	"github.com/stretchr/testify/require"
+)
+
+// buildTCPPacket returns a minimal serialized IPv4/TCP packet usable as Source.Read output.
+func buildTCPPacket(t *testing.T) []byte {
+	ip4 := &layers.IPv4{
+		Version:  4,
+		TTL:      123,
+		SrcIP:    net.ParseIP("127.0.0.1"),
+		DstIP:    net.ParseIP("127.0.0.2"),
+		Id:       41821,
+		Protocol: layers.IPProtocolTCP,
+	}
+	tcp := &layers.TCP{
+		SrcPort: layers.TCPPort(345),
+		DstPort: layers.TCPPort(678),
+		ACK:     true,
+		Seq:     1234,
+		Ack:     5678,
+		Window:  1024,
+	}
+	require.NoError(t, tcp.SetNetworkLayerForChecksum(ip4))
+
+	buf := gopacket.NewSerializeBuffer()
+	opts := gopacket.SerializeOptions{FixLengths: true, ComputeChecksums: true}
+	require.NoError(t, gopacket.SerializeLayers(buf, opts, ip4, tcp, gopacket.Payload([]byte{1})))
+	return buf.Bytes()
+}
+
+// delayedTimestampedSource simulates a capture backend that buffers/delays delivery
+// of a packet to userspace while still reporting the original kernel capture time.
+type delayedTimestampedSource struct {
+	packet    []byte
+	kernelTS  time.Time
+	sleepTime time.Duration
+}
+
+func (d *delayedTimestampedSource) Read(buf []byte) (int, error) {
+	time.Sleep(d.sleepTime)
+	return copy(buf, d.packet), nil
+}
+
+func (d *delayedTimestampedSource) Close() error                             { return nil }
+func (d *delayedTimestampedSource) SetReadDeadline(_ time.Time) error        { return nil }
+func (d *delayedTimestampedSource) SetPacketFilter(_ PacketFilterSpec) error { return nil }
+func (d *delayedTimestampedSource) LastPacketTimestamp() (time.Time, bool) {
+	return d.kernelTS, true
+}
+
+var _ Source = &delayedTimestampedSource{}
+var _ TimestampedSource = &delayedTimestampedSource{}
+
+func TestReadAndParseUsesKernelTimestampOverDelayedDelivery(t *testing.T) {
+	kernelTS := time.Now().Add(-500 * time.Millisecond)
+	source := &delayedTimestampedSource{
+		packet:    buildTCPPacket(t),
+		kernelTS:  kernelTS,
+		sleepTime: 50 * time.Millisecond,
+	}
+
+	parser := NewFrameParser()
+	receivedAt, err := ReadAndParse(source, make([]byte, 4096), parser)
+	require.NoError(t, err)
+
+	require.True(t, receivedAt.Equal(kernelTS), "expected the kernel capture timestamp, not delivery time")
+	require.Less(t, time.Since(receivedAt), 600*time.Millisecond)
+	require.Greater(t, time.Since(receivedAt), 400*time.Millisecond)
+}
+
+// plainSource has no timestamp capability, so ReadAndParse must fall back to time.Now().
+type plainSource struct {
+	packet []byte
+}
+
+func (p *plainSource) Read(buf []byte) (int, error)             { return copy(buf, p.packet), nil }
+func (p *plainSource) Close() error                             { return nil }
+func (p *plainSource) SetReadDeadline(_ time.Time) error        { return nil }
+func (p *plainSource) SetPacketFilter(_ PacketFilterSpec) error { return nil }
+
+var _ Source = &plainSource{}
+
+func TestReadAndParseFallsBackToNowWithoutKernelTimestamp(t *testing.T) {
+	source := &plainSource{packet: buildTCPPacket(t)}
+
+	parser := NewFrameParser()
+	before := time.Now()
+	receivedAt, err := ReadAndParse(source, make([]byte, 4096), parser)
+	after := time.Now()
+	require.NoError(t, err)
+
+	require.False(t, receivedAt.Before(before))
+	require.False(t, receivedAt.After(after))
+}

--- a/packets/packet_source_test.go
+++ b/packets/packet_source_test.go
@@ -77,8 +77,6 @@ func TestReadAndParseUsesKernelTimestampOverDelayedDelivery(t *testing.T) {
 	require.NoError(t, err)
 
 	require.True(t, receivedAt.Equal(kernelTS), "expected the kernel capture timestamp, not delivery time")
-	require.Less(t, time.Since(receivedAt), 600*time.Millisecond)
-	require.Greater(t, time.Since(receivedAt), 400*time.Millisecond)
 }
 
 // plainSource has no timestamp capability, so ReadAndParse must fall back to time.Now().

--- a/packets/packet_source_test.go
+++ b/packets/packet_source_test.go
@@ -105,3 +105,21 @@ func TestReadAndParseFallsBackToNowWithoutKernelTimestamp(t *testing.T) {
 	require.False(t, receivedAt.Before(before))
 	require.False(t, receivedAt.After(after))
 }
+
+func TestRTTFallsBackToNowOnClockStepBackward(t *testing.T) {
+	sendTime := time.Now()
+	// simulate a kernel capture timestamp that predates sendTime, e.g. because the
+	// system wall clock stepped backward between the two readings.
+	receivedAt := sendTime.Add(-time.Second)
+
+	rtt := RTT(receivedAt, sendTime)
+	require.GreaterOrEqual(t, rtt, time.Duration(0), "RTT must never be negative")
+}
+
+func TestRTTUsesCaptureTimestampWhenNonNegative(t *testing.T) {
+	sendTime := time.Now()
+	receivedAt := sendTime.Add(10 * time.Millisecond)
+
+	rtt := RTT(receivedAt, sendTime)
+	require.Equal(t, 10*time.Millisecond, rtt)
+}

--- a/packets/pcap_filter_test.go
+++ b/packets/pcap_filter_test.go
@@ -88,7 +88,7 @@ func TestFilterICMPPassesICMP(t *testing.T) {
 	buf := make([]byte, 4096)
 	parser := NewFrameParser()
 	require.NoError(t, source.SetReadDeadline(time.Now().Add(2*time.Second)))
-	err = ReadAndParse(source, buf, parser)
+	_, err = ReadAndParse(source, buf, parser)
 	require.NoError(t, err, "expected to capture ICMP packet")
 	assert.Equal(t, layers.LayerTypeICMPv4, parser.GetTransportLayer())
 }

--- a/packets/tcp_filter_test.go
+++ b/packets/tcp_filter_test.go
@@ -127,7 +127,7 @@ func doTestCase(t *testing.T, tc tcpTestCase) {
 	parser := NewFrameParser()
 
 	source.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
-	err = ReadAndParse(source, buffer, parser)
+	_, err = ReadAndParse(source, buffer, parser)
 
 	if !errors.Is(err, os.ErrDeadlineExceeded) {
 		// ErrDeadlineExceeded is what the test checks for, so we should only blow up on real errors

--- a/sack/sack_driver.go
+++ b/sack/sack_driver.go
@@ -158,7 +158,7 @@ func (s *sackDriver) getRTTFromRelSeq(relSeq uint32, receivedAt time.Time) (time
 	if s.sendTimes[relSeq].IsZero() {
 		return 0, fmt.Errorf("getRTTFromRelSeq: no probe sent for relative sequence number %d", relSeq)
 	}
-	return receivedAt.Sub(s.sendTimes[relSeq]), nil
+	return packets.RTT(receivedAt, s.sendTimes[relSeq]), nil
 }
 
 var errPacketDidNotMatchTraceroute = &common.ReceiveProbeNoPktError{Err: fmt.Errorf("packet did not match the traceroute")}

--- a/sack/sack_driver.go
+++ b/sack/sack_driver.go
@@ -104,12 +104,12 @@ func (s *sackDriver) ReceiveProbe(timeout time.Duration) (*common.ProbeResponse,
 	if err != nil {
 		return nil, fmt.Errorf("sackDriver failed to SetReadDeadline: %w", err)
 	}
-	err = packets.ReadAndParse(s.source, s.buffer, s.parser)
+	receivedAt, err := packets.ReadAndParse(s.source, s.buffer, s.parser)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.handleProbeLayers(s.parser)
+	return s.handleProbeLayers(s.parser, receivedAt)
 }
 
 func (s *sackDriver) ExpectedIPPair() packets.IPPair {
@@ -151,19 +151,19 @@ func getMinSack(localInitSeq uint32, opts []layers.TCPOption) (uint32, error) {
 	return minSack, nil
 }
 
-func (s *sackDriver) getRTTFromRelSeq(relSeq uint32) (time.Duration, error) {
+func (s *sackDriver) getRTTFromRelSeq(relSeq uint32, receivedAt time.Time) (time.Duration, error) {
 	if relSeq < uint32(s.params.ParallelParams.MinTTL) || relSeq > uint32(s.params.ParallelParams.MaxTTL) {
 		return 0, fmt.Errorf("getRTTFromRelSeq: invalid relative sequence number %d", relSeq)
 	}
 	if s.sendTimes[relSeq].IsZero() {
 		return 0, fmt.Errorf("getRTTFromRelSeq: no probe sent for relative sequence number %d", relSeq)
 	}
-	return time.Since(s.sendTimes[relSeq]), nil
+	return receivedAt.Sub(s.sendTimes[relSeq]), nil
 }
 
 var errPacketDidNotMatchTraceroute = &common.ReceiveProbeNoPktError{Err: fmt.Errorf("packet did not match the traceroute")}
 
-func (s *sackDriver) handleProbeLayers(parser *packets.FrameParser) (*common.ProbeResponse, error) {
+func (s *sackDriver) handleProbeLayers(parser *packets.FrameParser, receivedAt time.Time) (*common.ProbeResponse, error) {
 	ipPair, err := parser.GetIPPair()
 	if err != nil {
 		return nil, fmt.Errorf("sackDriver failed to get IP pair: %w", err)
@@ -193,7 +193,7 @@ func (s *sackDriver) handleProbeLayers(parser *packets.FrameParser) (*common.Pro
 				Err: fmt.Errorf("endpoint returned SACK-permitted but found no SACK options: %w", err),
 			}
 		}
-		rtt, err := s.getRTTFromRelSeq(relSeq)
+		rtt, err := s.getRTTFromRelSeq(relSeq, receivedAt)
 		if err != nil {
 			return nil, &common.BadPacketError{Err: fmt.Errorf("sackDriver failed to get RTT: %w", err)}
 		}
@@ -233,15 +233,15 @@ func (s *sackDriver) handleProbeLayers(parser *packets.FrameParser) (*common.Pro
 		}
 
 		relSeq := tcpInfo.Seq - s.state.localInitSeq
-		rtt, err := s.getRTTFromRelSeq(relSeq)
+		rtt, err := s.getRTTFromRelSeq(relSeq, receivedAt)
 		if err != nil {
 			return nil, &common.BadPacketError{Err: fmt.Errorf("sackDriver failed to get RTT: %w", err)}
 		}
 
 		return &common.ProbeResponse{
-			TTL:    uint8(relSeq),
-			IP:     ipPair.SrcAddr,
-			RTT:    rtt,
+			TTL: uint8(relSeq),
+			IP:  ipPair.SrcAddr,
+			RTT: rtt,
 			// Note that some servers don't properly reply with SACK responses, even if they respond with the
 			// SACK permitted option during the handshake.  In these cases an ICMP TTL Exceeded response from
 			// the destination indicates that we've reached the destination.
@@ -274,7 +274,7 @@ func (s *sackDriver) ReadHandshake(localPort uint16) error {
 	}
 	for !s.IsHandshakeFinished() {
 		// we should have already connected by now so it should be over quickly
-		err = packets.ReadAndParse(s.source, s.buffer, s.parser)
+		_, err = packets.ReadAndParse(s.source, s.buffer, s.parser)
 
 		if errors.Is(err, os.ErrDeadlineExceeded) {
 			return fmt.Errorf("sackDriver readHandshake timed out")

--- a/tcp/tcp_driver.go
+++ b/tcp/tcp_driver.go
@@ -153,12 +153,12 @@ func (t *tcpDriver) ReceiveProbe(timeout time.Duration) (*common.ProbeResponse, 
 		return nil, fmt.Errorf("tcpDriver failed to SetReadDeadline: %w", err)
 	}
 
-	err = packets.ReadAndParse(t.source, t.buffer, t.parser)
+	receivedAt, err := packets.ReadAndParse(t.source, t.buffer, t.parser)
 	if err != nil {
 		return nil, err
 	}
 
-	return t.handleProbeLayers()
+	return t.handleProbeLayers(receivedAt)
 }
 
 func (t *tcpDriver) ExpectedIPPair() packets.IPPair {
@@ -169,7 +169,7 @@ func (t *tcpDriver) ExpectedIPPair() packets.IPPair {
 	}
 }
 
-func (t *tcpDriver) handleProbeLayers() (*common.ProbeResponse, error) {
+func (t *tcpDriver) handleProbeLayers(receivedAt time.Time) (*common.ProbeResponse, error) {
 	ipPair, err := t.parser.GetIPPair()
 	if err != nil {
 		return nil, fmt.Errorf("tcpDriver failed to get IP pair: %w", err)
@@ -262,7 +262,7 @@ func (t *tcpDriver) handleProbeLayers() (*common.ProbeResponse, error) {
 	if probe == (probeData{}) {
 		return nil, common.ErrPacketDidNotMatchTraceroute
 	}
-	rtt := time.Since(probe.sendTime)
+	rtt := receivedAt.Sub(probe.sendTime)
 
 	return &common.ProbeResponse{
 		TTL:    probe.ttl,

--- a/tcp/tcp_driver.go
+++ b/tcp/tcp_driver.go
@@ -262,7 +262,7 @@ func (t *tcpDriver) handleProbeLayers(receivedAt time.Time) (*common.ProbeRespon
 	if probe == (probeData{}) {
 		return nil, common.ErrPacketDidNotMatchTraceroute
 	}
-	rtt := receivedAt.Sub(probe.sendTime)
+	rtt := packets.RTT(receivedAt, probe.sendTime)
 
 	return &common.ProbeResponse{
 		TTL:    probe.ttl,

--- a/tcp/tcp_driver_test.go
+++ b/tcp/tcp_driver_test.go
@@ -218,6 +218,70 @@ func TestTCPDriverTwoHops(t *testing.T) {
 	require.True(t, probeResp.IsDest)
 }
 
+// timestampedMockSource wraps a MockSource with a fixed kernel capture timestamp,
+// simulating a Source implementing packets.TimestampedSource.
+type timestampedMockSource struct {
+	*packets.MockSource
+	ts time.Time
+}
+
+func (t *timestampedMockSource) LastPacketTimestamp() (time.Time, bool) {
+	return t.ts, true
+}
+
+var _ packets.Source = &timestampedMockSource{}
+var _ packets.TimestampedSource = &timestampedMockSource{}
+
+func TestTCPDriverUsesKernelTimestampForRTT(t *testing.T) {
+	packets.RandomizePacketIDBase()
+
+	ctrl := gomock.NewController(t)
+	rawSource := packets.NewMockSource(ctrl)
+	mockSink := packets.NewMockSink(ctrl)
+
+	config := NewTCPv4(
+		net.ParseIP("1.2.3.4"),
+		80,
+		1,
+		30,
+		10*time.Millisecond,
+		1*time.Second,
+		false,
+		false,
+	)
+	config.srcIP = net.ParseIP("5.6.7.8")
+	config.srcPort = 12345
+
+	source := &timestampedMockSource{MockSource: rawSource}
+	driver := newTCPDriver(config, mockSink, source)
+
+	mockSink.EXPECT().WriteTo(gomock.Any(), gomock.Any()).Return(nil)
+	require.NoError(t, driver.SendProbe(1))
+	afterSend := time.Now()
+
+	// the kernel timestamp is set just after the probe was sent, implying a small,
+	// bounded RTT -- regardless of how long the simulated Read() delivery takes.
+	source.ts = afterSend.Add(20 * time.Millisecond)
+
+	ackPacket := mockTCPResp(t, config, true, true, false, driver.seqNum)
+	rawSource.EXPECT().SetReadDeadline(gomock.Any()).Return(nil)
+	rawSource.EXPECT().Read(gomock.Any()).DoAndReturn(func(buf []byte) (int, error) {
+		// simulate delivery arriving well after the packet was actually captured
+		time.Sleep(300 * time.Millisecond)
+		return copy(buf, ackPacket), nil
+	})
+
+	probeResp, err := driver.ReceiveProbe(1 * time.Second)
+	require.NoError(t, err)
+	require.True(t, probeResp.IsDest)
+
+	// if the driver used delivery time (time.Now()) instead of the kernel timestamp,
+	// RTT would be at least the 300ms artificial delivery delay.
+	require.GreaterOrEqual(t, probeResp.RTT, time.Duration(0))
+	require.Less(t, probeResp.RTT, 250*time.Millisecond,
+		"RTT should be computed from the kernel capture timestamp, not delayed delivery time")
+}
+
 func TestTCPDriverRST(t *testing.T) {
 	config, driver, mockSink, mockSource := initTest(t)
 

--- a/udp/udp_driver.go
+++ b/udp/udp_driver.go
@@ -122,15 +122,15 @@ func (u *udpDriver) ReceiveProbe(timeout time.Duration) (*common.ProbeResponse, 
 	if err != nil {
 		return nil, fmt.Errorf("udpDriver failed to SetReadDeadline: %w", err)
 	}
-	err = packets.ReadAndParse(u.source, u.buffer, u.parser)
+	receivedAt, err := packets.ReadAndParse(u.source, u.buffer, u.parser)
 	if err != nil {
 		return nil, err
 	}
 
-	return u.handleProbeLayers()
+	return u.handleProbeLayers(receivedAt)
 }
 
-func (u *udpDriver) handleProbeLayers() (*common.ProbeResponse, error) {
+func (u *udpDriver) handleProbeLayers(receivedAt time.Time) (*common.ProbeResponse, error) {
 	ipPair, err := u.parser.GetIPPair()
 	if err != nil {
 		return nil, fmt.Errorf("udpDriver failed to get IP pair: %w", err)
@@ -182,7 +182,7 @@ func (u *udpDriver) handleProbeLayers() (*common.ProbeResponse, error) {
 	if probe == (probeData{}) {
 		return nil, common.ErrPacketDidNotMatchTraceroute
 	}
-	rtt := time.Since(probe.sendTime)
+	rtt := receivedAt.Sub(probe.sendTime)
 
 	return &common.ProbeResponse{
 		TTL:    probe.ttl,

--- a/udp/udp_driver.go
+++ b/udp/udp_driver.go
@@ -182,7 +182,7 @@ func (u *udpDriver) handleProbeLayers(receivedAt time.Time) (*common.ProbeRespon
 	if probe == (probeData{}) {
 		return nil, common.ErrPacketDidNotMatchTraceroute
 	}
-	rtt := receivedAt.Sub(probe.sendTime)
+	rtt := packets.RTT(receivedAt, probe.sendTime)
 
 	return &common.ProbeResponse{
 		TTL:    probe.ttl,


### PR DESCRIPTION
## Summary
- Compute probe RTT from the kernel/BPF packet capture timestamp when the packet source can provide one, instead of the userspace time at which the packet happens to be read/processed. This avoids RTT inflation from capture delivery batching or scheduler delay.
- Add a `TimestampedSource` interface; `ReadAndParse` now returns the received-at timestamp, preferring the capture timestamp and falling back to `time.Now()` for sources that don't support it (Linux, Windows unaffected).
- macOS's `PcapSource` implements `TimestampedSource` via libpcap's `CaptureInfo.Timestamp`.
- Updated all four drivers (ICMP, UDP, TCP-SYN, SACK) to compute RTT from this timestamp instead of `time.Since(sendTime)`.

Closes #135. This is separate from #134 (macOS immediate-mode fix for the ~100ms RTT floor), per the issue's own scoping.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full suite)
- [x] New regression tests in `packets/packet_source_test.go`: simulate delayed packet delivery with a valid capture timestamp and assert RTT uses the capture timestamp, not delivery time; and assert fallback to `time.Now()` when no capture timestamp is available.
- [x] Manually verified real-world impact on macOS against loopback, `8.8.8.8`, and `www.sakura.ad.jp` for all four drivers using instrumented before/after RTT comparisons — kernel timestamps eliminate userspace scheduling jitter from RTT (up to tens of ms under load).

🤖 Generated with [Claude Code](https://claude.com/claude-code)